### PR TITLE
Catch Exceptions thrown by `pantheon_clear_edge_*()` functions

### DIFF
--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -26,9 +26,14 @@ function pantheon_wp_clear_edge_keys( $keys ) {
 	 */
 	do_action( 'pantheon_wp_clear_edge_keys', $keys );
 
-	if ( function_exists( 'pantheon_clear_edge_keys' ) ) {
-		pantheon_clear_edge_keys( $keys );
+	try {
+		if ( function_exists( 'pantheon_clear_edge_keys' ) ) {
+			pantheon_clear_edge_keys( $keys );
+		}
+	} catch ( Exception $e ) {
+		return new WP_Error( 'pantheon_clear_edge_keys', $e->getMessage() );
 	}
+	return true;
 }
 
 /**
@@ -45,9 +50,14 @@ function pantheon_wp_clear_edge_paths( $paths ) {
 	 */
 	do_action( 'pantheon_wp_clear_edge_paths', $paths );
 
-	if ( function_exists( 'pantheon_clear_edge_paths' ) ) {
-		pantheon_clear_edge_paths( $paths );
+	try {
+		if ( function_exists( 'pantheon_clear_edge_paths' ) ) {
+			pantheon_clear_edge_paths( $paths );
+		}
+	} catch ( Exception $e ) {
+		return new WP_Error( 'pantheon_clear_edge_paths', $e->getMessage() );
 	}
+	return true;
 }
 
 /**
@@ -60,9 +70,14 @@ function pantheon_wp_clear_edge_all() {
 	 */
 	do_action( 'pantheon_wp_clear_edge_all' );
 
-	if ( function_exists( 'pantheon_clear_edge_all' ) ) {
-		pantheon_clear_edge_all();
+	try {
+		if ( function_exists( 'pantheon_clear_edge_all' ) ) {
+			pantheon_clear_edge_all();
+		}
+	} catch ( Exception $e ) {
+		return new WP_Error( 'pantheon_clear_edge_all', $e->getMessage() );
 	}
+	return true;
 }
 
 /**

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -25,3 +25,4 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 require $_tests_dir . '/includes/bootstrap.php';
 
 require dirname( __FILE__ ) . '/class-pantheon-advanced-page-cache-testcase.php';
+require dirname( __FILE__ ) . '/pantheon-edge-functions.php';

--- a/tests/phpunit/pantheon-edge-functions.php
+++ b/tests/phpunit/pantheon-edge-functions.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Mock functions available in the Pantheon environment
+ *
+ * @package Pantheon_Advanced_Page_Cache
+ */
+
+/**
+ * Purge cache based on surrogate keys.
+ *
+ * @param array $keys Surrogate keys to purge.
+ * @throws Exception Keys are required.
+ * @return boolean
+ */
+function pantheon_clear_edge_keys( $keys ) {
+	if ( empty( $keys ) ) {
+		throw new Exception( 'Keys must not be empty' );
+	}
+	return true;
+}
+
+/**
+ * Purge cache based on paths.
+ *
+ * @param array $paths Paths to purge.
+ * @throws Exception Paths are required.
+ * @return boolean
+ */
+function pantheon_clear_edge_paths( $paths ) {
+	if ( empty( $paths ) ) {
+		throw new Exception( 'Paths must not be empty' );
+	}
+	return true;
+}
+
+/**
+ * Purge the entire cache.
+ *
+ * @throws Exception Globals are bad.
+ */
+function pantheon_clear_edge_all() {
+	if ( ! empty( $GLOBALS['pantheon_clear_edge_all_throw_exception'] ) ) {
+		throw new Exception( 'A global made me do this' );
+	}
+	return true;
+}

--- a/tests/phpunit/test-functions.php
+++ b/tests/phpunit/test-functions.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for the helper functions
+ *
+ * @package Pantheon_Advanced_Page_Cache
+ */
+
+/**
+ * Tests for the helper functions.
+ */
+class Test_Functions extends Pantheon_Advanced_Page_Cache_Testcase {
+
+	/**
+	 * Set up test function tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$GLOBALS['pantheon_clear_edge_all_throw_exception'] = false;
+	}
+
+	/**
+	 * Ensure Exception is caught when keys aren't supplied.
+	 */
+	public function test_clear_edge_keys_missing() {
+		$this->assertWPError( pantheon_wp_clear_edge_keys( array() ) );
+	}
+
+	/**
+	 * Ensure function returns true when keys are supplied.
+	 */
+	public function test_clear_edge_keys_exist() {
+		$this->assertTrue( pantheon_wp_clear_edge_keys( array( 'post-1' ) ) );
+	}
+
+	/**
+	 * Ensure Exception is caught when paths aren't supplied.
+	 */
+	public function test_clear_edge_paths_missing() {
+		$this->assertWPError( pantheon_wp_clear_edge_paths( array() ) );
+	}
+
+	/**
+	 * Ensure function returns true when paths are supplied.
+	 */
+	public function test_clear_edge_paths_exist() {
+		$this->assertTrue( pantheon_wp_clear_edge_paths( array( '/' ) ) );
+	}
+
+	/**
+	 * Ensure Exception is caught when there's an error flushing the cache
+	 */
+	public function test_clear_edge_all_exception() {
+		$GLOBALS['pantheon_clear_edge_all_throw_exception'] = true;
+		$this->assertWPError( pantheon_wp_clear_edge_all() );
+	}
+
+	/**
+	 * Ensure function returns true under normal operations.
+	 */
+	public function test_clear_edge_all_valid() {
+		$this->assertTrue( pantheon_wp_clear_edge_all() );
+	}
+
+}


### PR DESCRIPTION
While Exceptions are perfectly fine in PHPlandia, WordPress doesn't know
how to handle them. Instead, let's catch them and return `WP_Error`
objects instead.

Fixes #45