### PR TITLE
Ensure updates to post drafts don't flush the homepage cache

### DIFF
--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -18,7 +18,24 @@ class Purger {
 	 * @param integer $post_id ID for the modified post.
 	 */
 	public static function action_wp_insert_post( $post_id ) {
+		if ( 'publish' !== get_post_status( $post_id ) ) {
+			return;
+		}
 		self::purge_post_with_related( $post_id );
+	}
+
+	/**
+	 * Purge surrogate keys associated with a post being published or unpublished.
+	 *
+	 * @param string  $new_status New status for the post.
+	 * @param string  $old_status Old status for the post.
+	 * @param WP_Post $post Post object.
+	 */
+	public static function action_transition_post_status( $new_status, $old_status, $post ) {
+		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+			return;
+		}
+		self::purge_post_with_related( $post->ID );
 	}
 
 	/**

--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -116,6 +116,7 @@ add_filter( 'wp', array( 'Pantheon_Advanced_Page_Cache\Emitter', 'action_wp' ) )
  * Clears surrogate tags when various modification behaviors are performed.
  */
 add_action( 'wp_insert_post', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_wp_insert_post' ) );
+add_action( 'transition_post_status', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_transition_post_status' ), 10, 3 );
 add_action( 'before_delete_post', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_before_delete_post' ) );
 add_action( 'delete_attachment', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_delete_attachment' ) );
 add_action( 'clean_post_cache', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_clean_post_cache' ) );

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -79,6 +79,13 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 			'post_date_gmt' => '2016-10-15 11:00',
 			'post_name'     => 'third-post',
 		) );
+		$this->post_id4 = $this->factory->post->create( array(
+			'post_status'   => 'draft',
+			'post_author'   => $this->user_id2,
+			'post_date'     => '2016-10-15 11:00',
+			'post_date_gmt' => '2016-10-15 11:00',
+			'post_name'     => 'fourth-post',
+		) );
 		$this->page_id1 = $this->factory->post->create( array(
 			'post_status'   => 'publish',
 			'post_type'     => 'page',

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -14,17 +14,17 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 	 * Verify publishing a new post purges the homepage and associated archive pages.
 	 */
 	public function test_publish_post() {
-		$this->post_id4 = $this->factory->post->create( array(
+		$this->post_id5 = $this->factory->post->create( array(
 			'post_status'   => 'publish',
 			'post_author'   => $this->user_id1,
 			'post_date'     => '2016-10-21 12:00',
 			'post_date_gmt' => '2016-10-21 12:00',
-			'post_name'     => 'fourth-post',
+			'post_name'     => 'fifth-post',
 		) );
 		$this->assertClearedKeys( array(
 			'home',
 			'front',
-			'post-' . $this->post_id4,
+			'post-' . $this->post_id5,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
 		) );
@@ -42,6 +42,51 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		wp_update_post( array(
 			'ID'           => $this->post_id1,
 			'post_content' => 'Test content',
+		) );
+		$this->assertClearedKeys( array(
+			'home',
+			'front',
+			'post-' . $this->post_id1,
+			'user-' . $this->user_id1,
+			'term-' . $this->category_id1,
+			'term-' . $this->tag_id2,
+		) );
+		$this->assertPurgedURIs( array(
+			'/',
+			'/2016/',
+			'/2016/10/',
+			'/2016/10/14/',
+			'/2016/10/14/first-post/',
+			'/author/first-user/',
+			'/category/uncategorized/',
+			'/tag/second-tag/',
+		) );
+	}
+
+	/**
+	 * Verify updating a draft doesn't clear any keys
+	 */
+	public function test_update_post_draft() {
+		wp_update_post( array(
+			'ID'           => $this->post_id4,
+			'post_content' => 'Test content',
+		) );
+		$this->assertClearedKeys( array(
+			'post-' . $this->post_id4,
+			'term-' . $this->category_id1,
+		) );
+		$this->assertPurgedURIs( array(
+			'/category/uncategorized/',
+		) );
+	}
+
+	/**
+	 * Verify unpublishing a post clears the expected keys
+	 */
+	public function test_unpublish_post() {
+		wp_update_post( array(
+			'ID'           => $this->post_id1,
+			'post_status'  => 'draft',
 		) );
 		$this->assertClearedKeys( array(
 			'home',
@@ -145,6 +190,27 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		wp_update_post( array(
 			'ID'           => $this->page_id1,
 			'post_content' => 'Test content',
+		) );
+		$this->assertClearedKeys( array(
+			'home',
+			'front',
+			'post-' . $this->page_id1,
+			'user-' . $this->user_id1,
+		) );
+		$this->assertPurgedURIs( array(
+			'/',
+			'/author/first-user/',
+			'/first-page/',
+		) );
+	}
+
+	/**
+	 * Verify unpublishing a page clears the expected keys.
+	 */
+	public function test_unpublish_page() {
+		wp_update_post( array(
+			'ID'           => $this->page_id1,
+			'post_status'  => 'draft',
 		) );
 		$this->assertClearedKeys( array(
 			'home',


### PR DESCRIPTION
Only pay attention to the `wp_insert_post` action when the post is
published. Hook into `transition_post_status` for drafts going to
publish or vice versa.