### PR TITLE
Rename `Emitter::get_surrogate_keys()` to `Emitter::get_main_query_surrogate_keys()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Because cached responses include metadata describing the data therein, surrogate
 
 There is a limit to the number of surrogate keys in a response, so we've optimized them based on a user's expectation of a normal WordPress site. See the "Emitted Keys" section for full details.
 
-Use the `pantheon_wp_surrogate_keys` filter to customize surrogate keys in a response. For example, to include a surrogate key for a sidebar rendered on the homepage, you can filter the keys included in the response:
+Use the `pantheon_wp_main_query_surrogate_keys` filter to customize surrogate keys in a response. For example, to include a surrogate key for a sidebar rendered on the homepage, you can filter the keys included in the response:
 
     /**
      * Add surrogate key for the featured content sidebar rendered on the homepage.
      */
-    add_filter( 'pantheon_wp_surrogate_keys', function( $keys ){
+    add_filter( 'pantheon_wp_main_query_surrogate_keys', function( $keys ){
 	    if ( is_home() ) {
             $keys[] = 'sidebar-home-featured';
         }

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -17,7 +17,7 @@ class Emitter {
 	 */
 	public static function action_wp() {
 
-		$keys = self::get_surrogate_keys();
+		$keys = self::get_main_query_surrogate_keys();
 		if ( ! empty( $keys ) ) {
 			// @codingStandardsIgnoreStart
 			@header( 'Surrogate-Key: ' . implode( ' ', $keys ) );
@@ -32,7 +32,7 @@ class Emitter {
 	 *
 	 * @return array
 	 */
-	public static function get_surrogate_keys() {
+	public static function get_main_query_surrogate_keys() {
 		global $wp_query;
 
 		$keys = array();
@@ -101,7 +101,7 @@ class Emitter {
 		 *
 		 * @param array $keys Existing surrogate keys generate by the plugin.
 		 */
-		$keys = apply_filters( 'pantheon_wp_surrogate_keys', $keys );
+		$keys = apply_filters( 'pantheon_wp_main_query_surrogate_keys', $keys );
 		$keys = array_unique( $keys );
 		return $keys;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -44,12 +44,12 @@ Because cached responses include metadata describing the data therein, surrogate
 
 There is a limit to the number of surrogate keys in a response, so we've optimized them based on a user's expectation of a normal WordPress site. See the "Emitted Keys" section for full details.
 
-Use the `pantheon_wp_surrogate_keys` filter to customize surrogate keys in a response. For example, to include a surrogate key for a sidebar rendered on the homepage, you can filter the keys included in the response:
+Use the `pantheon_wp_main_query_surrogate_keys` filter to customize surrogate keys in a response. For example, to include a surrogate key for a sidebar rendered on the homepage, you can filter the keys included in the response:
 
     /**
      * Add surrogate key for the featured content sidebar rendered on the homepage.
      */
-    add_filter( 'pantheon_wp_surrogate_keys', function( $keys ){
+    add_filter( 'pantheon_wp_main_query_surrogate_keys', function( $keys ){
 	    if ( is_home() ) {
             $keys[] = 'sidebar-home-featured';
         }

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -188,7 +188,7 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 				$path .= '?' . $query;
 			}
 			$this->go_to( $view );
-			$this->view_surrogate_keys[ $path ] = Emitter::get_surrogate_keys();
+			$this->view_surrogate_keys[ $path ] = Emitter::get_main_query_surrogate_keys();
 		}
 	}
 

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -23,7 +23,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->post_id1,
 			'post-' . $this->post_id2,
 			'post-' . $this->post_id3,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -36,7 +36,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->post_id2,
 			'post-user-' . $this->user_id2,
 			'post-term-' . $this->category_id1,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -48,7 +48,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'single',
 			'post-' . $this->page_id1,
 			'post-user-' . $this->user_id1,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'single',
 			'post-' . $this->product_id1,
 			'post-term-' . $this->product_category_id2,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -72,7 +72,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'archive',
 			'user-' . $this->user_id1,
 			'post-' . $this->post_id1,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 		$this->assertArrayValues( array(
 			'archive',
 			'user-' . $this->user_id3,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -95,7 +95,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'archive',
 			'term-' . $this->tag_id2,
 			'post-' . $this->post_id1,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 		$this->assertArrayValues( array(
 			'archive',
 			'term-' . $this->tag_id1,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -118,7 +118,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'archive',
 			'term-' . $this->product_category_id1,
 			'post-' . $this->product_id2,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 		$this->assertArrayValues( array(
 			'archive',
 			'term-' . $this->product_category_id3,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -142,7 +142,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-type-archive',
 			'post-' . $this->product_id1,
 			'post-' . $this->product_id2,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -156,7 +156,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->post_id1,
 			'post-' . $this->post_id2,
 			'post-' . $this->post_id3,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function test_year_date_archive_without_posts() {
 		$this->go_to( home_url( '2015/' ) );
-		$this->assertArrayValues( array(), Emitter::get_surrogate_keys() );
+		$this->assertArrayValues( array(), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -178,7 +178,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->post_id1,
 			'post-' . $this->post_id2,
 			'post-' . $this->post_id3,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -186,7 +186,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function test_month_date_archive_without_posts() {
 		$this->go_to( home_url( '2015/10/' ) );
-		$this->assertArrayValues( array(), Emitter::get_surrogate_keys() );
+		$this->assertArrayValues( array(), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -198,7 +198,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'archive',
 			'date',
 			'post-' . $this->post_id3,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -206,7 +206,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function test_day_date_archive_without_posts() {
 		$this->go_to( home_url( '2015/10/15/' ) );
-		$this->assertArrayValues( array(), Emitter::get_surrogate_keys() );
+		$this->assertArrayValues( array(), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -223,7 +223,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->page_id1,
 			'post-' . $this->product_id1,
 			'post-' . $this->product_id2,
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 	/**
@@ -234,7 +234,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 		$this->assertArrayValues( array(
 			'search',
 			'search-no-results',
-		), Emitter::get_surrogate_keys() );
+		), Emitter::get_main_query_surrogate_keys() );
 	}
 
 }


### PR DESCRIPTION
This is more precise, and creates space for a second method specific to
REST API requests.

See #8