### PR TITLE
Prefix REST API surrogate keys with `rest-`

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -104,7 +104,7 @@ class Emitter {
 	 * @param WP_REST_Request  $request  Request object.
 	 */
 	public static function filter_rest_prepare_post( $response, $post, $request ) {
-		self::get_instance()->rest_api_surrogate_keys[] = 'post-' . $post->ID;
+		self::get_instance()->rest_api_surrogate_keys[] = 'rest-post-' . $post->ID;
 		return $response;
 	}
 
@@ -116,7 +116,7 @@ class Emitter {
 	 * @param WP_REST_Request  $request  Request object.
 	 */
 	public static function filter_rest_prepare_term( $response, $term, $request ) {
-		self::get_instance()->rest_api_surrogate_keys[] = 'term-' . $term->term_id;
+		self::get_instance()->rest_api_surrogate_keys[] = 'rest-term-' . $term->term_id;
 		return $response;
 	}
 
@@ -128,7 +128,7 @@ class Emitter {
 	 * @param WP_REST_Request  $request  Request object.
 	 */
 	public static function filter_rest_prepare_user( $response, $user, $request ) {
-		self::get_instance()->rest_api_surrogate_keys[] = 'user-' . $user->ID;
+		self::get_instance()->rest_api_surrogate_keys[] = 'rest-user-' . $user->ID;
 		return $response;
 	}
 

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -67,7 +67,7 @@ class Purger {
 		if ( $type && 'revision' === $type ) {
 			return;
 		}
-		pantheon_wp_clear_edge_keys( array( 'post-' . $post_id ) );
+		pantheon_wp_clear_edge_keys( array( 'post-' . $post_id, 'rest-post-' . $post_id ) );
 	}
 
 	/**
@@ -107,6 +107,7 @@ class Purger {
 		$term_ids = is_array( $term_ids ) ? $term_ids : array( $term_id );
 		foreach ( $term_ids as $term_id ) {
 			$keys[] = 'term-' . $term_id;
+			$keys[] = 'rest-term-' . $term_id;
 		}
 		pantheon_wp_clear_edge_keys( $keys );
 	}
@@ -151,7 +152,7 @@ class Purger {
 	 * @param integer $term_id ID for the modified term.
 	 */
 	private static function purge_term( $term_id ) {
-		pantheon_wp_clear_edge_keys( array( 'term-' . $term_id, 'post-term-' . $term_id ) );
+		pantheon_wp_clear_edge_keys( array( 'term-' . $term_id, 'rest-term-' . $term_id, 'post-term-' . $term_id ) );
 	}
 
 
@@ -163,6 +164,7 @@ class Purger {
 	public static function action_clean_user_cache( $user_id ) {
 		$keys = array(
 			'user-' . $user_id,
+			'rest-user-' . $user_id,
 		);
 		pantheon_wp_clear_edge_keys( $keys );
 	}

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -30,9 +30,9 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 3, $response->get_data() );
 		$this->assertArrayValues( array(
-			'post-' . $this->post_id1,
-			'post-' . $this->post_id2,
-			'post-' . $this->post_id3,
+			'rest-post-' . $this->post_id1,
+			'rest-post-' . $this->post_id2,
+			'rest-post-' . $this->post_id3,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -45,7 +45,7 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( $this->post_id2, $data['id'] );
 		$this->assertArrayValues( array(
-			'post-' . $this->post_id2,
+			'rest-post-' . $this->post_id2,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -57,7 +57,7 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 1, $response->get_data() );
 		$this->assertArrayValues( array(
-			'post-' . $this->page_id1,
+			'rest-post-' . $this->page_id1,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -70,7 +70,7 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( $this->page_id1, $data['id'] );
 		$this->assertArrayValues( array(
-			'post-' . $this->page_id1,
+			'rest-post-' . $this->page_id1,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -82,8 +82,8 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 2, $response->get_data() );
 		$this->assertArrayValues( array(
-			'term-' . $this->category_id1,
-			'term-' . $this->category_id2,
+			'rest-term-' . $this->category_id1,
+			'rest-term-' . $this->category_id2,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -96,7 +96,7 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( $this->category_id2, $data['id'] );
 		$this->assertArrayValues( array(
-			'term-' . $this->category_id2,
+			'rest-term-' . $this->category_id2,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -108,8 +108,8 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 2, $response->get_data() );
 		$this->assertArrayValues( array(
-			'term-' . $this->tag_id1,
-			'term-' . $this->tag_id2,
+			'rest-term-' . $this->tag_id1,
+			'rest-term-' . $this->tag_id2,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -122,7 +122,7 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( $this->tag_id1, $data['id'] );
 		$this->assertArrayValues( array(
-			'term-' . $this->tag_id1,
+			'rest-term-' . $this->tag_id1,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -134,8 +134,8 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 2, $response->get_data() );
 		$this->assertArrayValues( array(
-			'user-' . $this->user_id1,
-			'user-' . $this->user_id2,
+			'rest-user-' . $this->user_id1,
+			'rest-user-' . $this->user_id2,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -148,7 +148,7 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$data = $response->get_data();
 		$this->assertEquals( $this->user_id2, $data['id'] );
 		$this->assertArrayValues( array(
-			'user-' . $this->user_id2,
+			'rest-user-' . $this->user_id2,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -25,15 +25,15 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id5,
+			'rest-post-' . $this->post_id5,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
 			'/author/first-user/',
 			'/category/uncategorized/',
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 			'/wp-json/wp/v2/categories',
 			'/wp-json/wp/v2/categories/' . $this->category_id1,
 		) );
@@ -51,9 +51,12 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
+			'rest-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
+			'rest-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -68,8 +71,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/categories/' . $this->category_id1,
 			'/wp-json/wp/v2/tags',
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
 		) );
@@ -85,7 +86,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		) );
 		$this->assertClearedKeys( array(
 			'post-' . $this->post_id4,
+			'rest-post-' . $this->post_id4,
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/category/uncategorized/',
@@ -106,9 +109,12 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
+			'rest-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
+			'rest-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -123,8 +129,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/categories/' . $this->category_id1,
 			'/wp-json/wp/v2/tags',
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
 		) );
@@ -139,9 +143,12 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
+			'rest-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
+			'rest-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -156,8 +163,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/categories/' . $this->category_id1,
 			'/wp-json/wp/v2/tags',
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
 		) );
@@ -172,9 +177,12 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->post_id1,
+			'rest-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
+			'rest-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -189,8 +197,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/categories/' . $this->category_id1,
 			'/wp-json/wp/v2/tags',
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
 		) );
@@ -211,8 +217,10 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id2,
+			'rest-post-' . $this->page_id2,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -220,8 +228,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/category/uncategorized/',
 			'/wp-json/wp/v2/categories',
 			'/wp-json/wp/v2/categories/' . $this->category_id1,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 		) );
 	}
 
@@ -237,6 +243,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
+			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
@@ -245,8 +252,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 		) );
 	}
 
@@ -262,6 +267,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
+			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
@@ -270,8 +276,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 		) );
 	}
 
@@ -284,6 +288,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
+			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
@@ -292,8 +297,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 		) );
 	}
 
@@ -306,6 +309,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->page_id1,
+			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
@@ -314,8 +318,6 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 		) );
 	}
 
@@ -326,6 +328,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		clean_post_cache( $this->page_id1 );
 		$this->assertClearedKeys( array(
 			'post-' . $this->page_id1,
+			'rest-post-' . $this->page_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/first-page/',
@@ -351,7 +354,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id3,
+			'rest-post-' . $this->product_id3,
 			'term-' . $this->product_category_id1,
+			'rest-term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -371,7 +376,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id2,
+			'rest-post-' . $this->product_id2,
 			'term-' . $this->product_category_id1,
+			'rest-term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -390,7 +397,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id2,
+			'rest-post-' . $this->product_id2,
 			'term-' . $this->product_category_id1,
+			'rest-term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -409,7 +418,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $this->product_id2,
+			'rest-post-' . $this->product_id2,
 			'term-' . $this->product_category_id1,
+			'rest-term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -426,6 +437,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		clean_post_cache( $this->product_id1 );
 		$this->assertClearedKeys( array(
 			'post-' . $this->product_id1,
+			'rest-post-' . $this->product_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/product-category/second-product-category/',
@@ -450,13 +462,12 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'home',
 			'front',
 			'post-' . $attachment_id,
+			'rest-post-' . $attachment_id,
 			'user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
 			'/author/first-user/',
-			'/wp-json/wp/v2/users',
-			'/wp-json/wp/v2/users/' . $this->user_id1,
 		) );
 	}
 
@@ -467,6 +478,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		$this->tag_id3 = $this->factory->tag->create( array( 'slug' => 'third-tag' ) );
 		$this->assertClearedKeys( array(
 			'term-' . $this->tag_id3,
+			'rest-term-' . $this->tag_id3,
 			'post-term-' . $this->tag_id3,
 		) );
 		// Hasn't appeared on any views yet.
@@ -482,6 +494,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		) );
 		$this->assertClearedKeys( array(
 			'term-' . $this->tag_id2,
+			'rest-term-' . $this->tag_id2,
 			'post-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
@@ -499,6 +512,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		wp_delete_term( $this->tag_id2, 'post_tag' );
 		$this->assertClearedKeys( array(
 			'term-' . $this->tag_id2,
+			'rest-term-' . $this->tag_id2,
 			'post-term-' . $this->tag_id2,
 		) );
 		$this->assertPurgedURIs( array(
@@ -516,6 +530,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		clean_term_cache( $this->tag_id1 );
 		$this->assertClearedKeys( array(
 			'term-' . $this->tag_id1,
+			'rest-term-' . $this->tag_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/tag/first-tag/',
@@ -531,6 +546,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		clean_term_cache( $this->category_id1 );
 		$this->assertClearedKeys( array(
 			'term-' . $this->category_id1,
+			'rest-term-' . $this->category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/category/uncategorized/',
@@ -546,6 +562,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		clean_term_cache( $this->product_category_id1 );
 		$this->assertClearedKeys( array(
 			'term-' . $this->product_category_id1,
+			'rest-term-' . $this->product_category_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/product-category/first-product-category/',
@@ -559,6 +576,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		clean_user_cache( $this->user_id1 );
 		$this->assertClearedKeys( array(
 			'user-' . $this->user_id1,
+			'rest-user-' . $this->user_id1,
 		) );
 		$this->assertPurgedURIs( array(
 			'/author/first-user/',


### PR DESCRIPTION
Doing so gives us a greater degree of precision when triggering purges.

See #8