### PR TITLE
Emit surrogate keys for `/wp/v2/settings`; purge on `updated_option`

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -78,6 +78,7 @@ class Emitter {
 			self::get_instance()->rest_api_collection_endpoints[ $taxonomy->name ] = '/wp/v2/' . $taxonomy->rest_base;
 		}
 		add_filter( 'rest_prepare_user', array( __CLASS__, 'filter_rest_prepare_user' ), 10, 3 );
+		add_filter( 'rest_pre_get_setting', array( __CLASS__, 'filter_rest_pre_get_setting' ), 10, 2 );
 		self::get_instance()->rest_api_collection_endpoints['user'] = '/wp/v2/users';
 	}
 
@@ -151,6 +152,19 @@ class Emitter {
 			self::get_instance()->rest_api_surrogate_keys[] = 'rest-user-collection';
 		}
 		return $response;
+	}
+
+	/**
+	 * Determine which settings are present in a REST API request
+	 *
+	 * @param mixed  $result Value to use for the requested setting. Can be a scalar
+	 *                       matching the registered schema for the setting, or null to
+	 *                       follow the default get_option() behavior.
+	 * @param string $name   Setting name (as shown in REST API responses).
+	 */
+	public static function filter_rest_pre_get_setting( $result, $name ) {
+		self::get_instance()->rest_api_surrogate_keys[] = 'rest-setting-' . $name;
+		return $result;
 	}
 
 	/**

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -176,4 +176,21 @@ class Purger {
 		pantheon_wp_clear_edge_keys( $keys );
 	}
 
+	/**
+	 * Purge a variety of surrogate keys when an option is modified.
+	 *
+	 * @param string $option Name of the updated option.
+	 */
+	public static function action_updated_option( $option ) {
+		if ( ! function_exists( 'get_registered_settings' ) ) {
+			return;
+		}
+		$settings = get_registered_settings();
+		if ( empty( $settings[ $option ] ) || empty( $settings[ $option ]['show_in_rest'] ) ) {
+			return;
+		}
+		$rest_name = ! empty( $settings[ $option ]['show_in_rest']['name'] ) ? $settings[ $option ]['show_in_rest']['name'] : $option;
+		pantheon_wp_clear_edge_keys( array( 'rest-setting-' . $rest_name ) );
+	}
+
 }

--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -128,6 +128,7 @@ add_action( 'edited_term', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action
 add_action( 'delete_term', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_delete_term' ) );
 add_action( 'clean_term_cache', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_clean_term_cache' ) );
 add_action( 'clean_user_cache', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_clean_user_cache' ) );
+add_action( 'updated_option', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_updated_option' ) );
 
 /**
  * Registers the WP-CLI commands.

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -36,9 +36,10 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 
 		$this->setup_permalink_structure();
 
-		$this->user_id1 = $this->factory->user->create( array( 'user_role' => 'author', 'user_nicename' => 'first-user' ) );
-		$this->user_id2 = $this->factory->user->create( array( 'user_role' => 'author', 'user_nicename' => 'second-user' ) );
-		$this->user_id3 = $this->factory->user->create( array( 'user_role' => 'author', 'user_nicename' => 'third-user' ) );
+		$this->user_id1 = $this->factory->user->create( array( 'role' => 'author', 'user_nicename' => 'first-user' ) );
+		$this->user_id2 = $this->factory->user->create( array( 'role' => 'author', 'user_nicename' => 'second-user' ) );
+		$this->user_id3 = $this->factory->user->create( array( 'role' => 'author', 'user_nicename' => 'third-user' ) );
+		$this->admin_id1 = $this->factory->user->create( array( 'role' => 'administrator', 'user_nicename' => 'first-admin' ) );
 
 		$this->tag_id1 = $this->factory->tag->create( array( 'slug' => 'first-tag' ) );
 		$this->tag_id2 = $this->factory->tag->create( array( 'slug' => 'second-tag' ) );
@@ -220,6 +221,14 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 			$this->server->dispatch( $request );
 			$this->view_surrogate_keys[ '/wp-json' . $rest_api_route ] = Emitter::get_rest_api_surrogate_keys();
 		}
+		$current_user_id = get_current_user_id();
+		// Settings route needs an authenticated request.
+		wp_set_current_user( $this->admin_id1 );
+		$rest_api_route = '/wp/v2/settings';
+		$request = new WP_REST_Request( 'GET', $rest_api_route );
+		$this->server->dispatch( $request );
+		$this->view_surrogate_keys[ '/wp-json' . $rest_api_route ] = Emitter::get_rest_api_surrogate_keys();
+		wp_set_current_user( $current_user_id );
 	}
 
 	/**

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -157,4 +157,31 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
+	/**
+	 * Ensure GET /wp/v2/settings emits the expected surrogate keys
+	 */
+	public function test_get_settings() {
+		wp_set_current_user( $this->admin_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = $this->server->dispatch( $request );
+		$this->assertCount( 15, $response->get_data() );
+		$this->assertArrayValues( array(
+			'rest-setting-date_format',
+			'rest-setting-default_category',
+			'rest-setting-default_comment_status',
+			'rest-setting-default_ping_status',
+			'rest-setting-default_post_format',
+			'rest-setting-description',
+			'rest-setting-email',
+			'rest-setting-language',
+			'rest-setting-posts_per_page',
+			'rest-setting-start_of_week',
+			'rest-setting-time_format',
+			'rest-setting-timezone',
+			'rest-setting-title',
+			'rest-setting-url',
+			'rest-setting-use_smilies',
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
 }

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -593,6 +593,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 	 * Verify updating an option clears expected keys.
 	 */
 	public function test_update_option() {
+		if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
+			return $this->markTestSkipped( 'WordPress version not supported.' );
+		}
 		update_option( 'date_format', 'Y-m-d' );
 		$this->assertClearedKeys( array(
 			'rest-setting-date_format',
@@ -606,6 +609,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 	 * Verify updating an option not in the REST API doesn't clear keys.
 	 */
 	public function test_update_option_not_in_rest() {
+		if ( version_compare( $GLOBALS['wp_version'], '4.7-alpha', '<' ) ) {
+			return $this->markTestSkipped( 'WordPress version not supported.' );
+		}
 		update_option( 'papc_secret_email', 'foo@example.org' );
 		$this->assertClearedKeys( array() );
 		$this->assertPurgedURIs( array() );

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -589,4 +589,26 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		) );
 	}
 
+	/**
+	 * Verify updating an option clears expected keys.
+	 */
+	public function test_update_option() {
+		update_option( 'date_format', 'Y-m-d' );
+		$this->assertClearedKeys( array(
+			'rest-setting-date_format',
+		) );
+		$this->assertPurgedURIs( array(
+			'/wp-json/wp/v2/settings',
+		) );
+	}
+
+	/**
+	 * Verify updating an option not in the REST API doesn't clear keys.
+	 */
+	public function test_update_option_not_in_rest() {
+		update_option( 'papc_secret_email', 'foo@example.org' );
+		$this->assertClearedKeys( array() );
+		$this->assertPurgedURIs( array() );
+	}
+
 }


### PR DESCRIPTION
See #8