### PR TITLE
Purge post collection endpoints more liberally

### DIFF
--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -36,10 +36,7 @@ class Purger {
 			return;
 		}
 		self::purge_post_with_related( $post->ID );
-		// Clear the REST API collection endpoint when a new post is published.
-		if ( 'publish' !== $old_status && 'publish' === $new_status ) {
-			pantheon_wp_clear_edge_keys( array( 'rest-' . $post->post_type . '-collection' ) );
-		}
+		pantheon_wp_clear_edge_keys( array( 'rest-' . $post->post_type . '-collection' ) );
 	}
 
 	/**
@@ -49,6 +46,7 @@ class Purger {
 	 */
 	public static function action_before_delete_post( $post_id ) {
 		self::purge_post_with_related( $post_id );
+		pantheon_wp_clear_edge_keys( array( 'rest-' . get_post_type( $post_id ) . '-collection' ) );
 	}
 
 	/**
@@ -58,6 +56,7 @@ class Purger {
 	 */
 	public static function action_delete_attachment( $post_id ) {
 		self::purge_post_with_related( $post_id );
+		pantheon_wp_clear_edge_keys( array( 'rest-attachment-collection' ) );
 	}
 
 	/**

--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -112,7 +112,7 @@ add_action( 'wp_ajax_pantheon_clear_url_cache', array( 'Pantheon_Advanced_Page_C
  */
 add_filter( 'wp', array( 'Pantheon_Advanced_Page_Cache\Emitter', 'action_wp' ) );
 add_action( 'rest_api_init', array( 'Pantheon_Advanced_Page_Cache\Emitter', 'action_rest_api_init' ) );
-add_filter( 'rest_pre_dispatch', array( 'Pantheon_Advanced_Page_Cache\Emitter', 'filter_rest_pre_dispatch' ) );
+add_filter( 'rest_pre_dispatch', array( 'Pantheon_Advanced_Page_Cache\Emitter', 'filter_rest_pre_dispatch' ), 10, 3 );
 add_filter( 'rest_post_dispatch', array( 'Pantheon_Advanced_Page_Cache\Emitter', 'filter_rest_post_dispatch' ), 10, 2 );
 
 /**

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -24,5 +24,9 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
 
+if ( ! defined( 'REST_TESTS_IMPOSSIBLY_HIGH_NUMBER' ) ) {
+	define( 'REST_TESTS_IMPOSSIBLY_HIGH_NUMBER', 99999999 );
+}
+
 require dirname( __FILE__ ) . '/class-pantheon-advanced-page-cache-testcase.php';
 require dirname( __FILE__ ) . '/pantheon-edge-functions.php';

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -38,6 +38,19 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
+	 * Ensure GET /wp/v2/posts with no items emits the expected surrogate keys
+	 */
+	public function test_get_posts_no_results() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'author', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
+		$response = $this->server->dispatch( $request );
+		$this->assertCount( 0, $response->get_data() );
+		$this->assertArrayValues( array(
+			'rest-post-collection',
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
+	/**
 	 * Ensure GET /wp/v2/post/<id> emits the expected surrogate keys
 	 */
 	public function test_get_post() {
@@ -73,6 +86,32 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$this->assertEquals( $this->page_id1, $data['id'] );
 		$this->assertArrayValues( array(
 			'rest-post-' . $this->page_id1,
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
+	/**
+	 * Ensure GET /wp/v2/media emits the expected surrogate keys
+	 */
+	public function test_get_media() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
+		$response = $this->server->dispatch( $request );
+		$this->assertCount( 1, $response->get_data() );
+		$this->assertArrayValues( array(
+			'rest-attachment-collection',
+			'rest-post-' . $this->attachment_id1,
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
+	/**
+	 * Ensure GET /wp/v2/media emits the expected surrogate keys
+	 */
+	public function test_get_medii() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/media/' . $this->attachment_id1 );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $this->attachment_id1, $data['id'] );
+		$this->assertArrayValues( array(
+			'rest-post-' . $this->attachment_id1,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -38,6 +38,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/categories',
 			'/wp-json/wp/v2/categories/' . $this->category_id1,
+			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -59,6 +60,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
 			'rest-term-' . $this->tag_id2,
+			'rest-post-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -75,6 +77,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -117,6 +120,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
 			'rest-term-' . $this->tag_id2,
+			'rest-post-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -133,6 +137,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -151,6 +156,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
 			'rest-term-' . $this->tag_id2,
+			'rest-post-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -167,6 +173,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -185,6 +192,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-term-' . $this->category_id1,
 			'term-' . $this->tag_id2,
 			'rest-term-' . $this->tag_id2,
+			'rest-post-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -201,6 +209,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -228,6 +237,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/',
 			'/author/first-user/',
 			'/wp-json/wp/v2/pages',
+			'/wp-json/wp/v2/pages?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -245,6 +255,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
+			'rest-page-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -252,6 +263,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
+			'/wp-json/wp/v2/pages?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -269,6 +281,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
+			'rest-page-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -276,6 +289,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
+			'/wp-json/wp/v2/pages?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -290,6 +304,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
+			'rest-page-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -297,6 +312,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
+			'/wp-json/wp/v2/pages?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -311,6 +327,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
+			'rest-page-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -318,6 +335,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/first-page/',
 			'/wp-json/wp/v2/pages',
 			'/wp-json/wp/v2/pages/' . $this->page_id1,
+			'/wp-json/wp/v2/pages?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 
@@ -380,6 +398,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-post-' . $this->product_id2,
 			'term-' . $this->product_category_id1,
 			'rest-term-' . $this->product_category_id1,
+			'rest-product-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -401,6 +420,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-post-' . $this->product_id2,
 			'term-' . $this->product_category_id1,
 			'rest-term-' . $this->product_category_id1,
+			'rest-product-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -422,6 +442,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-post-' . $this->product_id2,
 			'term-' . $this->product_category_id1,
 			'rest-term-' . $this->product_category_id1,
+			'rest-product-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
@@ -451,24 +472,23 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 	 * Verify deleting an attachment clears expected keys.
 	 */
 	public function test_delete_attachment() {
-		$attachment_id = $this->factory->post->create( array(
-			'post_mime_type' => 'image/jpeg',
-			'post_type'      => 'attachment',
-			'post_author'    => $this->user_id1,
-		) );
-		// Ignore the original insert event.
-		$this->cleared_keys = array();
-		wp_delete_attachment( $attachment_id );
+		$post_name = get_post_field( 'post_name', $this->attachment_id1 );
+		wp_delete_attachment( $this->attachment_id1, true );
 		$this->assertClearedKeys( array(
 			'home',
 			'front',
-			'post-' . $attachment_id,
-			'rest-post-' . $attachment_id,
+			'post-' . $this->attachment_id1,
+			'rest-post-' . $this->attachment_id1,
 			'user-' . $this->user_id1,
+			'rest-attachment-collection',
 		) );
 		$this->assertPurgedURIs( array(
 			'/',
 			'/author/first-user/',
+			'/' . $post_name . '/',
+			'/wp-json/wp/v2/media',
+			'/wp-json/wp/v2/media/' . $this->attachment_id1,
+			'/wp-json/wp/v2/media?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
 


### PR DESCRIPTION
When a post is updated, we don't know how its new values will affect the
collections it's represented in. As such, we need to purge all possible
collections, instead of the collections it was previously present in.

Behavior only affects updates to published posts, because the assumption
is that unpublished posts won't ever be cached.

See #8