### PR TITLE
Emit surrogate keys for `/wp/v2/comments` endpoints

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -77,6 +77,8 @@ class Emitter {
 			add_filter( "rest_prepare_{$taxonomy->name}", array( __CLASS__, 'filter_rest_prepare_term' ), 10, 3 );
 			self::get_instance()->rest_api_collection_endpoints[ '/wp/v2/' . $taxonomy->rest_base ] = $taxonomy->name;
 		}
+		add_filter( 'rest_prepare_comment', array( __CLASS__, 'filter_rest_prepare_comment' ), 10, 3 );
+		self::get_instance()->rest_api_collection_endpoints['/wp/v2/comments'] = 'comment';
 		add_filter( 'rest_prepare_user', array( __CLASS__, 'filter_rest_prepare_user' ), 10, 3 );
 		add_filter( 'rest_pre_get_setting', array( __CLASS__, 'filter_rest_pre_get_setting' ), 10, 2 );
 		self::get_instance()->rest_api_collection_endpoints['/wp/v2/users'] = 'user';
@@ -133,6 +135,18 @@ class Emitter {
 	 */
 	public static function filter_rest_prepare_term( $response, $term, $request ) {
 		self::get_instance()->rest_api_surrogate_keys[] = 'rest-term-' . $term->term_id;
+		return $response;
+	}
+
+	/**
+	 * Determine which comments are present in a REST API response.
+	 *
+	 * @param WP_REST_Response $response The response object.
+	 * @param WP_Comment       $comment  The original comment object.
+	 * @param WP_REST_Request  $request  Request used to generate the response.
+	 */
+	public static function filter_rest_prepare_comment( $response, $comment, $request ) {
+		self::get_instance()->rest_api_surrogate_keys[] = 'rest-comment-' . $comment->comment_ID;
 		return $response;
 	}
 

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -112,6 +112,12 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 		) );
 		wp_set_object_terms( $this->product_id2, array( $this->product_category_id1 ), 'product_category' );
 
+		$this->comment_id1 = $this->factory->comment->create( array(
+			'comment_post_ID'  => $this->post_id1,
+			'comment_approved' => 1,
+			'user_id'          => 0,
+		) );
+
 		$this->attachment_id1 = $this->factory->post->create( array(
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -170,6 +170,45 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
+	 * Ensure GET /wp/v2/comments emits the expected surrogate keys
+	 */
+	public function test_get_comments() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$response = $this->server->dispatch( $request );
+		$this->assertCount( 1, $response->get_data() );
+		$this->assertArrayValues( array(
+			'rest-comment-collection',
+			'rest-comment-' . $this->comment_id1,
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
+	/**
+	 * Ensure GET /wp/v2/comments without results emits the expected surrogate keys
+	 */
+	public function test_get_comments_no_results() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
+		$response = $this->server->dispatch( $request );
+		$this->assertCount( 0, $response->get_data() );
+		$this->assertArrayValues( array(
+			'rest-comment-collection',
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
+	/**
+	 * Ensure GET /wp/v2/comments/<id> emits the expected surrogate keys
+	 */
+	public function test_get_comment() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments/' . $this->comment_id1 );
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+		$this->assertEquals( $this->comment_id1, $data['id'] );
+		$this->assertArrayValues( array(
+			'rest-comment-' . $this->comment_id1,
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
+	/**
 	 * Ensure GET /wp/v2/users emits the expected surrogate keys
 	 */
 	public function test_get_users() {


### PR DESCRIPTION
See #8