### PR TITLE
Purge comment endpoints when a post is updated

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -147,6 +147,7 @@ class Emitter {
 	 */
 	public static function filter_rest_prepare_comment( $response, $comment, $request ) {
 		self::get_instance()->rest_api_surrogate_keys[] = 'rest-comment-' . $comment->comment_ID;
+		self::get_instance()->rest_api_surrogate_keys[] = 'rest-comment-post-' . $comment->comment_post_ID;
 		return $response;
 	}
 

--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -118,7 +118,7 @@ add_filter( 'rest_post_dispatch', array( 'Pantheon_Advanced_Page_Cache\Emitter',
 /**
  * Clears surrogate tags when various modification behaviors are performed.
  */
-add_action( 'wp_insert_post', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_wp_insert_post' ) );
+add_action( 'wp_insert_post', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_wp_insert_post' ), 10, 2 );
 add_action( 'transition_post_status', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_transition_post_status' ), 10, 3 );
 add_action( 'before_delete_post', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_before_delete_post' ) );
 add_action( 'delete_attachment', array( 'Pantheon_Advanced_Page_Cache\Purger', 'action_delete_attachment' ) );

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -218,6 +218,8 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 		}
 		$rest_api_routes[] = '/wp/v2/media';
 		$rest_api_routes[] = '/wp/v2/media/' . $this->attachment_id1;
+		$rest_api_routes[] = '/wp/v2/comments';
+		$rest_api_routes[] = '/wp/v2/comments/' . $this->comment_id1;
 		$views = array_unique( $views );
 		foreach ( $views as $view ) {
 			$path = parse_url( $view, PHP_URL_PATH );
@@ -250,6 +252,10 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 		$request->set_param( 'parent', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$this->server->dispatch( $request );
 		$this->view_surrogate_keys[ '/wp-json/wp/v2/media?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ] = Emitter::get_rest_api_surrogate_keys();
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'post', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
+		$this->server->dispatch( $request );
+		$this->view_surrogate_keys[ '/wp-json/wp/v2/comments?post=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ] = Emitter::get_rest_api_surrogate_keys();
 		// Settings route needs an authenticated request.
 		$current_user_id = get_current_user_id();
 		wp_set_current_user( $this->admin_id1 );

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -174,11 +174,13 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function test_get_comments() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$comment = get_comment( $this->comment_id1 );
 		$response = $this->server->dispatch( $request );
 		$this->assertCount( 1, $response->get_data() );
 		$this->assertArrayValues( array(
 			'rest-comment-collection',
 			'rest-comment-' . $this->comment_id1,
+			'rest-comment-post-' . $comment->comment_post_ID,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 
@@ -199,12 +201,14 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 	 * Ensure GET /wp/v2/comments/<id> emits the expected surrogate keys
 	 */
 	public function test_get_comment() {
+		$comment = get_comment( $this->comment_id1 );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments/' . $this->comment_id1 );
 		$response = $this->server->dispatch( $request );
 		$data = $response->get_data();
 		$this->assertEquals( $this->comment_id1, $data['id'] );
 		$this->assertArrayValues( array(
 			'rest-comment-' . $this->comment_id1,
+			'rest-comment-post-' . $comment->comment_post_ID,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -26,6 +26,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->post_id5,
 			'rest-post-' . $this->post_id5,
+			'rest-comment-post-' . $this->post_id5,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
 			'rest-term-' . $this->category_id1,
@@ -55,6 +56,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->post_id1,
 			'rest-post-' . $this->post_id1,
+			'rest-comment-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
 			'rest-term-' . $this->category_id1,
@@ -77,6 +79,8 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/comments',
+			'/wp-json/wp/v2/comments/' . $this->comment_id1,
 			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
@@ -115,6 +119,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->post_id1,
 			'rest-post-' . $this->post_id1,
+			'rest-comment-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
 			'rest-term-' . $this->category_id1,
@@ -137,6 +142,8 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/comments',
+			'/wp-json/wp/v2/comments/' . $this->comment_id1,
 			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
@@ -151,6 +158,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->post_id1,
 			'rest-post-' . $this->post_id1,
+			'rest-comment-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
 			'rest-term-' . $this->category_id1,
@@ -173,6 +181,8 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/comments',
+			'/wp-json/wp/v2/comments/' . $this->comment_id1,
 			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
@@ -187,6 +197,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->post_id1,
 			'rest-post-' . $this->post_id1,
+			'rest-comment-post-' . $this->post_id1,
 			'user-' . $this->user_id1,
 			'term-' . $this->category_id1,
 			'rest-term-' . $this->category_id1,
@@ -209,6 +220,8 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'/wp-json/wp/v2/tags/' . $this->tag_id2,
 			'/wp-json/wp/v2/posts',
 			'/wp-json/wp/v2/posts/' . $this->post_id1,
+			'/wp-json/wp/v2/comments',
+			'/wp-json/wp/v2/comments/' . $this->comment_id1,
 			'/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
 		) );
 	}
@@ -230,6 +243,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->page_id2,
 			'rest-post-' . $this->page_id2,
+			'rest-comment-post-' . $this->page_id2,
 			'user-' . $this->user_id1,
 			'rest-page-collection',
 		) );
@@ -254,6 +268,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
+			'rest-comment-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 			'rest-page-collection',
 		) );
@@ -280,6 +295,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
+			'rest-comment-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 			'rest-page-collection',
 		) );
@@ -303,6 +319,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
+			'rest-comment-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 			'rest-page-collection',
 		) );
@@ -326,6 +343,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->page_id1,
 			'rest-post-' . $this->page_id1,
+			'rest-comment-post-' . $this->page_id1,
 			'user-' . $this->user_id1,
 			'rest-page-collection',
 		) );
@@ -479,6 +497,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'front',
 			'post-' . $this->attachment_id1,
 			'rest-post-' . $this->attachment_id1,
+			'rest-comment-post-' . $this->attachment_id1,
 			'user-' . $this->user_id1,
 			'rest-attachment-collection',
 		) );


### PR DESCRIPTION
Because a post's visibility affects a comment's visibility, we need to
purge comment endpoints when the post's visibility changes.

See #8