### PR TITLE
Permit flush URL cache if `delete_others_posts` or `manage_options`

### DIFF
--- a/inc/class-user-interface.php
+++ b/inc/class-user-interface.php
@@ -18,7 +18,7 @@ class User_Interface {
 	 * @param object $wp_admin_bar Instance of WP_Admin_Bar.
 	 */
 	public static function action_admin_bar_menu( $wp_admin_bar ) {
-		if ( is_admin() || ! is_user_logged_in() || ! current_user_can( 'delete_others_posts' ) ) {
+		if ( is_admin() || ! is_user_logged_in() || ! ( current_user_can( 'delete_others_posts' ) || current_user_can( 'manage_options' ) ) ) {
 			return;
 		}
 

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -243,6 +243,9 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 	 * Ensure GET /wp/v2/settings emits the expected surrogate keys
 	 */
 	public function test_get_settings() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Test only applicable on single site.' );
+		}
 		wp_set_current_user( $this->admin_id1 );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
 		$response = $this->server->dispatch( $request );


### PR DESCRIPTION
Doing so lets both editors and admins flush the cache.

Previously https://github.com/pantheon-systems/WordPress/pull/71