### PR TITLE
Disable emitting surrogate keys for the admin, unless added by filter

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -258,6 +258,11 @@ class Emitter {
 			}
 		}
 
+		// Don't emit surrogate keys in the admin, unless defined by the filter.
+		if ( is_admin() ) {
+			$keys = array();
+		}
+
 		/**
 		 * Customize surrogate keys sent in the header.
 		 *


### PR DESCRIPTION
See https://github.com/pantheon-systems/pantheon-advanced-page-cache/issues/88#issuecomment-303839274