### PR TITLE
Ensure use of `?_embed` emits correct surrogate keys

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -105,7 +105,6 @@ class Emitter {
 	 * @param WP_REST_Request $request Request used to generate the response.
 	 */
 	public static function filter_rest_pre_dispatch( $result, $server, $request ) {
-		self::get_instance()->rest_api_surrogate_keys = array();
 		if ( isset( self::get_instance()->rest_api_collection_endpoints[ $request->get_route() ] ) ) {
 			self::get_instance()->rest_api_surrogate_keys[] = 'rest-' . self::get_instance()->rest_api_collection_endpoints[ $request->get_route() ] . '-collection';
 		}
@@ -302,6 +301,13 @@ class Emitter {
 		$keys = array_unique( $keys );
 		$keys = self::filter_huge_surrogate_keys_list( $keys );
 		return $keys;
+	}
+
+	/**
+	 * Reset surrogate keys stored on the instance.
+	 */
+	public static function reset_rest_api_surrogate_keys() {
+		self::get_instance()->rest_api_surrogate_keys = array();
 	}
 
 	/**

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -144,7 +144,7 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 
 		$this->cleared_keys = array();
 		$this->setup_view_surrogate_keys();
-		Pantheon_Advanced_Page_Cache\Emitter::reset_rest_api_surrogate_keys();
+		Emitter::reset_rest_api_surrogate_keys();
 
 		add_action( 'pantheon_wp_clear_edge_keys', array( $this, 'action_pantheon_wp_clear_edge_keys' ) );
 	}
@@ -260,24 +260,29 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 			$request = new WP_REST_Request( 'GET', $rest_api_route );
 			$this->server->dispatch( $request );
 			$this->view_surrogate_keys[ '/wp-json' . $rest_api_route ] = Emitter::get_rest_api_surrogate_keys();
+			Emitter::reset_rest_api_surrogate_keys();
 		}
 		// Routes with no items present.
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'author', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$this->server->dispatch( $request );
 		$this->view_surrogate_keys[ '/wp-json/wp/v2/posts?author=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ] = Emitter::get_rest_api_surrogate_keys();
+		Emitter::reset_rest_api_surrogate_keys();
 		$request = new WP_REST_Request( 'GET', '/wp/v2/pages' );
 		$request->set_param( 'parent', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$this->server->dispatch( $request );
 		$this->view_surrogate_keys[ '/wp-json/wp/v2/pages?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ] = Emitter::get_rest_api_surrogate_keys();
+		Emitter::reset_rest_api_surrogate_keys();
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
 		$request->set_param( 'parent', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$this->server->dispatch( $request );
 		$this->view_surrogate_keys[ '/wp-json/wp/v2/media?parent=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ] = Emitter::get_rest_api_surrogate_keys();
+		Emitter::reset_rest_api_surrogate_keys();
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'post', REST_TESTS_IMPOSSIBLY_HIGH_NUMBER );
 		$this->server->dispatch( $request );
 		$this->view_surrogate_keys[ '/wp-json/wp/v2/comments?post=' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ] = Emitter::get_rest_api_surrogate_keys();
+		Emitter::reset_rest_api_surrogate_keys();
 		// Settings route needs an authenticated request.
 		$current_user_id = get_current_user_id();
 		wp_set_current_user( $this->admin_id1 );
@@ -285,6 +290,7 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'GET', $rest_api_route );
 		$this->server->dispatch( $request );
 		$this->view_surrogate_keys[ '/wp-json' . $rest_api_route ] = Emitter::get_rest_api_surrogate_keys();
+		Emitter::reset_rest_api_surrogate_keys();
 		wp_set_current_user( $current_user_id );
 	}
 

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -144,6 +144,7 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 
 		$this->cleared_keys = array();
 		$this->setup_view_surrogate_keys();
+		Pantheon_Advanced_Page_Cache\Emitter::reset_rest_api_surrogate_keys();
 
 		add_action( 'pantheon_wp_clear_edge_keys', array( $this, 'action_pantheon_wp_clear_edge_keys' ) );
 	}

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -50,6 +50,15 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 			'rest-post-' . $this->post_id1,
 			'rest-post-' . $this->post_id2,
 			'rest-post-' . $this->post_id3,
+			'rest-comment-collection',
+			'rest-comment-' . $this->comment_id1,
+			'rest-comment-post-' . $this->post_id1,
+			'rest-category-collection',
+			'rest-term-1',
+			'rest-post_tag-collection',
+			'rest-term-' . $this->tag_id2,
+			'rest-user-' . $this->user_id1,
+			'rest-user-' . $this->user_id2,
 		), Emitter::get_rest_api_surrogate_keys() );
 	}
 

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -38,6 +38,22 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
+	 * Ensure GET /wp/v2/posts?_embed emits the expected surrogate keys
+	 */
+	public function test_get_posts_embed() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$response = $this->server->dispatch( $request );
+		$data = $this->server->response_to_data( $response, true );
+		$this->assertCount( 3, $data );
+		$this->assertArrayValues( array(
+			'rest-post-collection',
+			'rest-post-' . $this->post_id1,
+			'rest-post-' . $this->post_id2,
+			'rest-post-' . $this->post_id3,
+		), Emitter::get_rest_api_surrogate_keys() );
+	}
+
+	/**
 	 * Ensure GET /wp/v2/posts with no items emits the expected surrogate keys
 	 */
 	public function test_get_posts_no_results() {


### PR DESCRIPTION
Fixes #102 