### PR TITLE
clear_edge_all() for nav_menu_item updates

### DIFF
--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -70,6 +70,9 @@ class Purger {
 		if ( $type && 'revision' === $type ) {
 			return;
 		}
+    if ( $type && 'nav_menu_item' === $type ) {
+      return;
+    }
 		pantheon_wp_clear_edge_keys( array( 'post-' . $post_id, 'rest-post-' . $post_id, 'post-huge', 'rest-post-huge' ) );
 	}
 
@@ -163,6 +166,10 @@ class Purger {
 		if ( 'revision' === $post->post_type ) {
 			return;
 		}
+    if ( 'nav_menu_item' === $post->post_type ) {
+      pantheon_clear_edge_all();
+      return;
+    }
 		$keys   = array(
 			'home',
 			'front',


### PR DESCRIPTION
Changes @ /wp-admin/nav-menus.php trigger for every term `purge_term` and `action_clean_term_cache` and for every item `action_clean_post_cache` and `purge_post_with_related`.

There is not a lot we can do about it in the current setup, but we can at least make sure that it clears the whole cache as this most likely impacts the whole site.

(Alternative: Find a way to add the relevant menu term to every page and use them instead)