### PR TITLE
Add more text to fix parsing issue on WordPress.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Piping to `grep` will filter the output down to just the `Surrogate-Key-Raw` hea
 
     curl -IH "Pantheon-Debug:1" https://scalewp.io/ | grep -i Surrogate-Key-Raw
 
+Tada!
+
 ## Emitted Keys and Purge Events ##
 
 ### Emitted Keys on Traditional Views ###

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,8 @@ Piping to `grep` will filter the output down to just the `Surrogate-Key-Raw` hea
 
     curl -IH "Pantheon-Debug:1" https://scalewp.io/ | grep -i Surrogate-Key-Raw
 
+Tada!
+
 == Emitted Keys and Purge Events =
 
 = Emitted Keys on Traditional Views =


### PR DESCRIPTION
See https://wordpress.org/support/topic/minor-typo-in-documentation/