### PR TITLE
handle models that are not instances of the Model class

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -382,9 +382,13 @@ class Emitter {
 	/**
 	 * Inspect the model and get the right surrogate keys.
 	 *
-	 * @param WPGraphQL\Model\Model $model Model object.
+	 * @param WPGraphQL\Model\Model|mixed $model Model object, array, etc.
 	 */
 	public static function filter_graphql_dataloader_get_model( $model ) {
+		if ( ! $model instanceof \WPGraphQL\Model\Model ) {
+			return $model;
+		}
+
 		$reflect              = new \ReflectionClass( $model );
 		$class_short_name     = $reflect->getShortName();
 		$surrogate_key_prefix = strtolower( $class_short_name );


### PR DESCRIPTION
Fixes #202

I’m using the woocommerce plugin and getting the same error mentioned in #202. Rather than an instance of `\WPGraphQL\Model\Model`, the plugin is receiving an array that looks like this:

```json
{
    "download_url": "https:\/\/www.example.com\/?download_file=3725&order=wc_order_EYw4cHxUlpAsV&email=john.ode%40example.com&key=fa5895b4-16aa-4826-8b20-ca8fcfbdb857",
    "download_id": "fa5895b4-16aa-4826-8b20-ca8fcfbdb857",
    "product_id": 3725,
    "product_name": "Example Product - Audio",
    "product_url": "https:\/\/www.example.com\/product\/example-product\/?attribute_pa_download-options=audio",
    "download_name": "Example Product (audiobook .zip file)",
    "order_id": 10501,
    "order_key": "wc_order_EYw4cHxUlpAsV",
    "downloads_remaining": "",
    "access_expires": null,
    "file": {
        "name": "Example Product (audiobook .zip file)",
        "file": "https:\/\/example.s3.us-east-2.amazonaws.com\/pda\/www.example.com\/wp-content\/uploads\/woocommerce_uploads\/example-product-audiobook.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=…"
    }
}
```

Since we can’t reliably infer the model name or database ID for any possible array that the plugin might receive, I figured it was probably best to bypass creating surrogate keys.