### PR TITLE
Add specific surrogate key for post type archives

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -267,6 +267,7 @@ class Emitter {
 			$keys[] = 'archive';
 			if ( is_post_type_archive() ) {
 				$keys[] = 'post-type-archive';
+				$keys[] = get_query_var( 'post_type' ) . '-archive';
 			} elseif ( is_author() ) {
 				$user_id = get_queried_object_id();
 				if ( $user_id ) {

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -236,6 +236,7 @@ class Purger {
 		$keys   = array(
 			'home',
 			'front',
+			$post->post_type . '-archive',
 			'404',
 			'feed',
 			'post-' . $post->ID,

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -30,6 +30,22 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
+	 * Assert expected surrogate keys for the product archive
+	 */
+	public function test_single_product() {
+		$this->go_to( get_post_type_archive_link( 'product' ) );
+		$this->assertArrayValues(
+			array(
+				'archive',
+				'post-type-archive',
+				'product-archive',
+				'post-' . $this->$this->product_id1,
+			),
+			Emitter::get_main_query_surrogate_keys()
+		);
+	}
+
+	/**
 	 * Assert expected surrogate keys for a single post.
 	 */
 	public function test_single_post() {

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -587,6 +587,7 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 				'home',
 				'front',
 				'feed',
+				'product-archive',
 				'404',
 				'post-' . $this->product_id3,
 				'post-huge',


### PR DESCRIPTION
Adds a surrogate key to post-type archive pages (eg, "portfolio) that's specific to that archive( eg `portfolio-archive`)

Also clears the post type archive when a post of that type is updated
