### PR TITLE
Fix README Header Spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Pantheon Advanced Page Cache #
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07) [jspellman](https://profiles.wordpress.org/jspellman/) [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/) [ryanshoover](https://profiles.wordpress.org/ryanshoover/) [rwagner00](https://profiles.wordpress.org/rwagner00/)
-**Tags:** pantheon, cdn, cache
-**Requires at least:** 4.7
-**Tested up to:** 6.2
-**Stable tag:** 1.2.4
-**License:** GPLv2 or later
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/)  
+**Tags:** pantheon, cdn, cache  
+**Requires at least:** 4.7  
+**Tested up to:** 6.2  
+**Stable tag:** 1.2.4  
+**License:** GPLv2 or later  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
 Automatically clear related pages from Pantheon's Edge when you update content. High TTL. Fresh content. Visitors never wait.
 


### PR DESCRIPTION
Fixes newline spacing inadvertently dropped in #229