### PR TITLE
[BUGS-5914] Send the header to the result and not the server

### DIFF
--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -132,8 +132,8 @@ class Emitter {
 	 */
 	public static function filter_rest_post_dispatch( $result, $server ) {
 		$keys = self::get_rest_api_surrogate_keys();
-		if ( ! empty( $keys ) ) {
-			$server->send_header( self::HEADER_KEY, implode( ' ', $keys ) );
+		if ( ! empty( $keys ) && $result instanceof \WP_REST_Response ) {
+			$result->header( self::HEADER_KEY, implode( ' ', $keys ) );
 		}
 		return $result;
 	}


### PR DESCRIPTION
Instead of sending the header to the server, attach the header to the response.

This fixes an issue when `rest_preload_api_request()` is used to preload a REST API request. This causes a `Cannot modify header information - headers already sent by ...` error because the code was trying to send the header directly in the preloaded request. The plugin should instead append the headers to the REST response vs outputting it straight away.