### PR TITLE
Lint README for lost spacing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: Lint and Test
+
+on: push
+
+jobs:
+  validate-readme-spacing:
+    name: Validate README Spacing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: pantheon-systems/validate-readme-spacing@v1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 **Tested up to:** 6.2  
 **Stable tag:** 1.3.1-dev  
 **License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Automatically clear related pages from Pantheon's Edge when you update content. High TTL. Fresh content. Visitors never wait.
 


### PR DESCRIPTION
Ensures the header section of README.md handles newlines correctly in rendered markdown.

See https://github.com/pantheon-systems/validate-readme-spacing