### PR TITLE
[BUGS-3964] Add filter to skips surrogate keys for taxonomy terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,17 @@ Different WordPress actions cause different surrogate keys to be purged, documen
 * Purges surrogate keys: `rest-setting-<name>`
 * Affected views: REST API resource endpoint
 
+## Surrogate Keys for taxonomy terms ##
+Setting surrogate keys for posts with large numbers of taxonomies (such as WooCommerce products with a large number of global attributes) can suffer from slower queries. Surrogate keys can be skipped for 'product' post types' taxonomy terms (or any other criteria you see fit) with the following filter:
+
+``` php
+function custom_should_add_terms($should_add_terms, $wp_query) {
+    if ( $wp_query->is_singular( 'product' ) ) {
+        return false;
+    }
+    return $should_add_terms;
+}
+add_filter('pantheon_should_add_terms', 'custom_should_add_terms', 10, 2);
 ```
 
 ## Plugin Integrations ##
@@ -312,7 +323,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 
 ### Latest ###
 * Bumped Dependencies [[236](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/236)]
-* Disabled surrogate keys for 'product' post types' taxonomy terms [[239](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/239)]
+* Add filter `pantheon_should_add_terms` to allow disabling surrogate keys for posts' taxonomy terms [[239](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/239)]
 
 ### 1.3.0 (April 19, 2023) ###
 * Adds support for WordPress Multisite which resolves issue where editing a Post on one subsite clears the home page cache of other sites in the Multisite install if it has a Post containing the same ID [[#228](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/228)].

--- a/README.md
+++ b/README.md
@@ -296,11 +296,6 @@ Different WordPress actions cause different surrogate keys to be purged, documen
 * Purges surrogate keys: `rest-setting-<name>`
 * Affected views: REST API resource endpoint
 
-## Surrogate Keys for 'product' post types ##
-Surrogate keys are skipped for 'product' post types' taxonomy terms for performance. This can be overridden, or further customized with the `pantheon_should_add_terms` filter.
-
-```
-add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
 ```
 
 ## Plugin Integrations ##

--- a/README.md
+++ b/README.md
@@ -296,6 +296,13 @@ Different WordPress actions cause different surrogate keys to be purged, documen
 * Purges surrogate keys: `rest-setting-<name>`
 * Affected views: REST API resource endpoint
 
+## Surrogate Keys for 'product' post types ##
+Surrogate keys are skipped for 'product' post types' taxonomy terms for performance. This can be overridden, or further customized with the `pantheon_should_add_terms` filter.
+
+```
+add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
+```
+
 ## Plugin Integrations ##
 
 Pantheon Advanced Page Cache integrates with WordPress plugins, including:
@@ -310,6 +317,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 
 ### Latest ###
 * Bumped Dependencies [[236](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/236)]
+* Disabled surrogate keys for 'product' post types' taxonomy terms [[239](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/239)]
 
 ### 1.3.0 (April 19, 2023) ###
 * Adds support for WordPress Multisite which resolves issue where editing a Post on one subsite clears the home page cache of other sites in the Multisite install if it has a Post containing the same ID [[#228](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/228)].

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -253,9 +253,9 @@ class Emitter {
 					 * @param $add_terms whether or not to create surrogate keys for a given post's taxonomy terms.
 					 * @param $wp_query the full WP_Query object.
 					 * @return bool
-					 * usage: add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
+					 * usage: add_filter( 'pantheon_should_add_terms',"__return_false", 10, 2);
 					 */
-					$add_terms = apply_filters( 'pantheon_should_add_terms', ! $wp_query->is_singular( 'product' ), $wp_query );
+					$add_terms = apply_filters( 'pantheon_should_add_terms', true, $wp_query );
 					if ( ! $add_terms ) {
 						continue;
 					}

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -241,10 +241,24 @@ class Emitter {
 		if ( ! empty( $wp_query->posts ) ) {
 			foreach ( $wp_query->posts as $p ) {
 				$keys[] = 'post-' . $p->ID;
-				if ( $wp_query->is_singular() || $wp_query->is_page() ) {
+				if ( $wp_query->is_singular() ) {
 					if ( post_type_supports( $p->post_type, 'author' ) ) {
 						$keys[] = 'post-user-' . $p->post_author;
 					}
+
+					/**
+					 * filter pantheon_should_add_terms
+					 * skips surrogate keys for products' taxonomies and terms
+					 * @param $add_terms whether or not to create surrogate keys for a given post's taxonomy terms.
+					 * @param $wp_query the full WP_Query object.
+					 * @return bool
+					 * usage: add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
+					 */
+					$add_terms = apply_filters( 'pantheon_should_add_terms', ! $wp_query->is_singular('product'), $wp_query );
+					if ( ! $add_terms ) {
+						continue;
+					}
+
 					foreach ( get_object_taxonomies( $p ) as $tax ) {
 						$terms = get_the_terms( $p->ID, $tax );
 						if ( $terms && ! is_wp_error( $terms ) ) {
@@ -257,7 +271,7 @@ class Emitter {
 			}
 		}
 
-		if ( is_singular() || is_page() ) {
+		if ( is_singular() ) {
 			$keys[] = 'single';
 			if ( is_attachment() ) {
 				$keys[] = 'attachment';

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -247,8 +247,8 @@ class Emitter {
 					}
 
 					/**
-					 * filter pantheon_should_add_terms
-					 * skips surrogate keys for products' taxonomies and terms
+					 * Filter pantheon_should_add_terms
+					 * Skips surrogate keys for products' taxonomies and terms
 					 *
 					 * @param $add_terms whether or not to create surrogate keys for a given post's taxonomy terms.
 					 * @param $wp_query the full WP_Query object.

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -248,7 +248,7 @@ class Emitter {
 
 					/**
 					 * Filter pantheon_should_add_terms
-					 * Skips surrogate keys for products' taxonomy terms
+					 * Gives the option to skip taxonomy terms for a given post
 					 *
 					 * @param $add_terms whether or not to create surrogate keys for a given post's taxonomy terms.
 					 * @param $wp_query the full WP_Query object.

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -248,7 +248,7 @@ class Emitter {
 
 					/**
 					 * Filter pantheon_should_add_terms
-					 * Skips surrogate keys for products' taxonomies and terms
+					 * Skips surrogate keys for products' taxonomy terms
 					 *
 					 * @param $add_terms whether or not to create surrogate keys for a given post's taxonomy terms.
 					 * @param $wp_query the full WP_Query object.

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -249,12 +249,13 @@ class Emitter {
 					/**
 					 * filter pantheon_should_add_terms
 					 * skips surrogate keys for products' taxonomies and terms
+					 *
 					 * @param $add_terms whether or not to create surrogate keys for a given post's taxonomy terms.
 					 * @param $wp_query the full WP_Query object.
 					 * @return bool
 					 * usage: add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
 					 */
-					$add_terms = apply_filters( 'pantheon_should_add_terms', ! $wp_query->is_singular('product'), $wp_query );
+					$add_terms = apply_filters( 'pantheon_should_add_terms', ! $wp_query->is_singular( 'product' ), $wp_query );
 					if ( ! $add_terms ) {
 						continue;
 					}

--- a/readme.txt
+++ b/readme.txt
@@ -291,6 +291,13 @@ Different WordPress actions cause different surrogate keys to be purged, documen
 * Purges surrogate keys: `rest-setting-<name>`
 * Affected views: REST API resource endpoint
 
+= Surrogate Keys for 'product' post types =
+Surrogate keys are skipped for 'product' post types' taxonomy terms for performance. This can be overridden, or further customized with the `pantheon_should_add_terms` filter.
+
+```
+add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
+```
+
 ## Plugin Integrations ##
 
 Pantheon Advanced Page Cache integrates with WordPress plugins, including:
@@ -305,6 +312,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/mast
 
 = Latest =
 * Bumped Dependencies [[236](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/236)]
+* Disabled surrogate keys for 'product' post types' taxonomy terms [[239](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/239)]
 
 = 1.3.0 =
 * Adds support for WordPress Multisite which resolves issue where editing a Post on one subsite clears the home page cache of other sites in the Multisite install if it has a Post containing the same ID [[#228](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/228)].

--- a/readme.txt
+++ b/readme.txt
@@ -291,13 +291,6 @@ Different WordPress actions cause different surrogate keys to be purged, documen
 * Purges surrogate keys: `rest-setting-<name>`
 * Affected views: REST API resource endpoint
 
-= Surrogate Keys for 'product' post types =
-Surrogate keys are skipped for 'product' post types' taxonomy terms for performance. This can be overridden, or further customized with the `pantheon_should_add_terms` filter.
-
-```
-add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
-```
-
 ## Plugin Integrations ##
 
 Pantheon Advanced Page Cache integrates with WordPress plugins, including:

--- a/readme.txt
+++ b/readme.txt
@@ -291,7 +291,20 @@ Different WordPress actions cause different surrogate keys to be purged, documen
 * Purges surrogate keys: `rest-setting-<name>`
 * Affected views: REST API resource endpoint
 
-## Plugin Integrations ##
+== Surrogate Keys for taxonomy terms ==
+Setting surrogate keys for posts with large numbers of taxonomies (such as WooCommerce products with a large number of global attributes) can suffer from slower queries. Surrogate keys can be skipped for 'product' post types' taxonomy terms (or any other criteria you see fit) with the following filter:
+
+```
+function custom_should_add_terms($should_add_terms, $wp_query) {
+    if ( $wp_query->is_singular( 'product' ) ) {
+        return false;
+    }
+    return $should_add_terms;
+}
+add_filter('pantheon_should_add_terms', 'custom_should_add_terms', 10, 2);
+```
+
+== Plugin Integrations ==
 
 Pantheon Advanced Page Cache integrates with WordPress plugins, including:
 
@@ -305,7 +318,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/mast
 
 = Latest =
 * Bumped Dependencies [[236](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/236)]
-* Disabled surrogate keys for 'product' post types' taxonomy terms [[239](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/239)]
+* Add filter `pantheon_should_add_terms` to allow disabling surrogate keys for posts' taxonomy terms [[239](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/239)]
 
 = 1.3.0 =
 * Adds support for WordPress Multisite which resolves issue where editing a Post on one subsite clears the home page cache of other sites in the Multisite install if it has a Post containing the same ID [[#228](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/228)].

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -136,7 +136,6 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 				array(
 					'single',
 					'post-' . $this->product_id1,
-					'post-term-' . $this->product_category_id2,
 				),
 				Emitter::get_main_query_surrogate_keys()
 			);
@@ -145,7 +144,6 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 				array(
 					'blog-1-single',
 					'blog-1-post-' . $this->product_id1,
-					'blog-1-post-term-' . $this->product_category_id2,
 				),
 				Emitter::get_main_query_surrogate_keys()
 			);
@@ -595,6 +593,34 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			}
 			$this->assertArrayValues( array( 'blog-1-post-huge', 'blog-1-post-term-1', 'blog-1-post-term-5', 'blog-1-post' ), Pantheon_Advanced_Page_Cache\Emitter::filter_huge_surrogate_keys_list( $keys ) );
 		}
+	}
+
+	/**
+	 * Assert expected surrogate keys for a single product when filter is overriden to add them.
+	 */
+	public function test_surrogate_keys_with_filter_override() {
+		add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
+		$this->go_to( get_permalink( $this->product_id1 ) );
+		if ( ! is_multisite() ) {
+			$this->assertArrayValues(
+				array(
+					'single',
+					'post-' . $this->product_id1,
+					'post-term-' . $this->product_category_id2,
+				),
+				Emitter::get_main_query_surrogate_keys()
+			);
+		} else {
+			$this->assertArrayValues(
+				array(
+					'blog-1-single',
+					'blog-1-post-' . $this->product_id1,
+					'blog-1-post-term-' . $this->product_category_id2,
+				),
+				Emitter::get_main_query_surrogate_keys()
+			);
+		}
+		remove_all_filters("pantheon_should_add_terms");
 	}
 
 }

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -136,6 +136,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 				array(
 					'single',
 					'post-' . $this->product_id1,
+					'post-term-' . $this->product_category_id2,
 				),
 				Emitter::get_main_query_surrogate_keys()
 			);
@@ -144,6 +145,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 				array(
 					'blog-1-single',
 					'blog-1-post-' . $this->product_id1,
+					'blog-1-post-term-' . $this->product_category_id2,
 				),
 				Emitter::get_main_query_surrogate_keys()
 			);
@@ -596,17 +598,16 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
-	 * Assert expected surrogate keys for a single product when filter is overriden to add them.
+	 * Assert no surrogate keys for a single product when filter is overriden to skip them.
 	 */
 	public function test_surrogate_keys_with_filter_override() {
-		add_filter( 'pantheon_should_add_terms',"__return_true", 10, 2);
+		add_filter( 'pantheon_should_add_terms',"__return_false", 10, 2);
 		$this->go_to( get_permalink( $this->product_id1 ) );
 		if ( ! is_multisite() ) {
 			$this->assertArrayValues(
 				array(
 					'single',
 					'post-' . $this->product_id1,
-					'post-term-' . $this->product_category_id2,
 				),
 				Emitter::get_main_query_surrogate_keys()
 			);
@@ -615,7 +616,6 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 				array(
 					'blog-1-single',
 					'blog-1-post-' . $this->product_id1,
-					'blog-1-post-term-' . $this->product_category_id2,
 				),
 				Emitter::get_main_query_surrogate_keys()
 			);


### PR DESCRIPTION
- add new filter `pantheon_should_add_terms`
- `$wp_query->is_singular() || $wp_query->is_page()` is redundant