### PR TITLE
[BUGS-5914] Add PHP unit test cases for GraphQL and REST API response headers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,17 +25,20 @@ The `master` branch matches the latest stable release deployed to [wp.org](wp.or
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
 1. Open a Pull Request to merge `release_X.Y.Z` into `master`. Your PR should consist of all commits to `develop` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
-1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `master`. "Rebase and merge" is preferred in this case. _Never_ squash to `master`.
+1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `master`. "Merge" is preferred in this case, not rebase. _Never_ squash to `master`.
 1. Pull `master` locally, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
 1. Confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
-1. Create a [new release](https://github.com/pantheon-systems/pantheon-advanced-page-cache/releases/new) using the tag created in the previous steps, naming the release with the new version number, and targeting the tag created in the previous step. Paste the release changelog from the `Changelog` section of [the readme](readme.txt) into the body of the release, including the links to the closed issues if applicable.
+1. Create a [new release](https://github.com/pantheon-systems/pantheon-advanced-page-cache/releases/new) using the tag created in the previous steps, naming the release with the new version number, and targeting the tag created in the previous step. Use the "Generate Release Notes" button.
+    * This can be done with `gh` with the following: `gh release create "X.Y.Z" -t "X.Y.Z" --generate-notes`
 1. Wait for the [_Release pantheon-advanced-page-cache plugin to wp.org_ action](https://github.com/pantheon-systems/pantheon-advanced-page-cache/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org plugin repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
 1. Check WordPress.org: Ensure that the changes are live on [the plugin repository](https://wordpress.org/plugins/pantheon-advanced-page-cache/). This may take a few minutes.
 1. Following the release, prepare the next dev version with the following steps:
+    * `git checkout master`
+    * `git pull origin master`
     * `git checkout develop`
     * `git rebase master`
     * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
-    * Add a new `** Latest **` heading to the changelog
+    * Add a new `** X.Y.X-dev **` heading to the changelog in readme.txt and README.md
     * `git add -A .`
     * `git commit -m "Prepare X.Y.X-dev"`
     * `git push origin develop`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 4.7  
-**Tested up to:** 6.2  
+**Tested up to:** 6.3
 **Stable tag:** 1.4.1-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pantheon Advanced Page Cache #
 
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)
-**Tags:** pantheon, cdn, cache  
-**Requires at least:** 4.7  
+**Tags:** pantheon, cdn, cache
+**Requires at least:** 4.7
 **Tested up to:** 6.3
-**Stable tag:** 1.4.1-dev  
-**License:** GPLv2 or later  
+**Stable tag:** 1.4.1-dev
+**License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Automatically clear related pages from Pantheon's Edge when you update content. High TTL. Fresh content. Visitors never wait.
@@ -322,7 +322,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 ## Changelog ##
 
 ### 1.4.1-dev ###
-* Send the REST API response header to the result and not the REST server [[#237](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/237)]. Props [@srtfisher](https://github.com/srtfisher) & [@felixarntz](https://github.com/felixarntz)j.
+* Send the REST API response header to the result and not the REST server [[#237](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/237)]. Props [@srtfisher](https://github.com/srtfisher) & [@felixarntz](https://github.com/felixarntz).
 
 ### 1.4.0 ###
 * Bumped Dependencies [[236](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/236)]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pantheon Advanced Page Cache #
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/)  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 4.7  
 **Tested up to:** 6.2  

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 ## Changelog ##
 
 ### 1.4.1-dev ###
+* Send the REST API response header to the result and not the REST server [[#237](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/237)]. Props [@srtfisher](https://github.com/srtfisher) & [@felixarntz](https://github.com/felixarntz)j.
 
 ### 1.4.0 ###
 * Bumped Dependencies [[236](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/236)]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pantheon Advanced Page Cache #
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)
-**Tags:** pantheon, cdn, cache
-**Requires at least:** 4.7
-**Tested up to:** 6.3
-**Stable tag:** 1.4.1-dev
-**License:** GPLv2 or later
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
+**Tags:** pantheon, cdn, cache  
+**Requires at least:** 4.7  
+**Tested up to:** 6.3  
+**Stable tag:** 1.4.1-dev  
+**License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Automatically clear related pages from Pantheon's Edge when you update content. High TTL. Fresh content. Visitors never wait.

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Pantheon Advanced Page Cache ===
-Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00
+Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler
 Tags: pantheon, cdn, cache
 Requires at least: 4.7
-Tested up to: 6.2
+Tested up to: 6.3
 Stable tag: 1.4.1-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -315,6 +315,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/mast
 == Changelog ==
 
 = 1.4.1-dev =
+* Send the REST API response header to the result and not the REST server [[#237](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/237)]. Props [@srtfisher](https://github.com/srtfisher) & [@felixarntz](https://github.com/felixarntz).
 
 = 1.4.0 =
 * Bumped Dependencies [[236](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/236)]

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -610,6 +610,32 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		);
 	}
 
+	/**
+     * Test headers set on a REST API response.
+     */
+	public function test_rest_api_response_headers() {
+		// Add the filter to include the test key
+		add_filter('pantheon_wp_rest_api_surrogate_keys', function ($keys) {
+			$keys[] = 'test-key';
+			return $keys;
+		});
+
+		// Create a new instance of WP_REST_Response
+		$response = new WP_REST_Response( [ 'foo' => 'bar' ] );
+		$server = rest_get_server();
+
+		// Fire up the filter to capture the headers from the response.
+		$rest_post_dispatch = Emitter::filter_rest_post_dispatch( $response, $server );
+		$actual_headers = $rest_post_dispatch->headers;
+
+		// Define your expected surrogate keys
+		$expected_surrogate_keys = Emitter::get_rest_api_surrogate_keys();
+
+		// Verify that the headers were set correctly
+		$this->assertContains( 'test-key', $expected_surrogate_keys );
+		$this->assertArrayHasKey( 'Surrogate-Key', $actual_headers );
+		$this->assertEquals( $actual_headers['Surrogate-Key'], implode( ' ', $expected_surrogate_keys ) );
+	}
 
     /**
      * Test headers set on a GraphQL response.

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -656,7 +656,8 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
         // Call the filter_graphql_response_headers_to_send() method
         $result_headers = Emitter::filter_graphql_response_headers_to_send($existing_headers);
 
-		$expected_headers = array_merge( $existing_headers, [ 'Surrogate-Key' => 'graphql-collection test-key' ] );
+		$graphql_collection_key = is_multisite() ? 'blog-1-graphql-collection' : 'graphql-collection';
+		$expected_headers = array_merge( $existing_headers, [ 'Surrogate-Key' => "$graphql_collection_key test-key" ] );
         // Verify that the existing headers are preserved
         $this->assertEquals($expected_headers, $result_headers);
 

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -610,4 +610,34 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		);
 	}
 
+
+    /**
+     * Test headers set on a GraphQL response.
+     */
+    public function test_graphql_response_headers() {
+        // Set up the mock response array with the existing headers set by the GraphQL plugin
+        $existing_headers = [
+            'header1' => 'value1',
+            'header2' => 'value2',
+        ];
+
+        // Simulate adding a surrogate key via a filter
+        add_filter('pantheon_wp_graphql_surrogate_keys', function ($keys) {
+            $keys[] = 'test-key';
+            return $keys;
+        });
+
+        // Call the filter_graphql_response_headers_to_send() method
+        $result_headers = Emitter::filter_graphql_response_headers_to_send($existing_headers);
+
+		$expected_headers = array_merge( $existing_headers, [ 'Surrogate-Key' => 'graphql-collection test-key' ] );
+        // Verify that the existing headers are preserved
+        $this->assertEquals($expected_headers, $result_headers);
+
+        // Verify that the 'Surrogate-Key' header was added with the expected value
+        $expected_surrogate_keys = Emitter::get_graphql_surrogate_keys();
+        $this->assertArrayHasKey(Emitter::HEADER_KEY, $result_headers);
+        $this->assertEquals(implode(' ', $expected_surrogate_keys), $result_headers[Emitter::HEADER_KEY]);
+		$this->assertContains( 'test-key', $expected_surrogate_keys );
+    }
 }


### PR DESCRIPTION
This closes the loop on #217 #237 because we didn't actually have any tests validating the REST (or GraphQL) responses and that they contain the Surrogate Key headers. This PR adds two new tests in `test-emitter-rest-api.php` -- one that tests the REST APi headers to ensure that they contain the expected surrogate keys, and the other to test the GraphQL response for the same. While the `test_graphql_response_headers` test doesn't _really_ make a lot of sense inside the `*rest-api.php` test case, given it's the only test of its kind, I opted to keep it in the existing "API stuff" test suite rather than starting a new one, particularly since the REST API tests were already broken out of `test-emitter.php`. If/when we have more GraphQL-specific tests, we can create a `test-emitter-graphql.php` or rename `test-emitter-rest-api.php` to `test-emitter-apis.php` or something, but that seemed unnecessary for a single test case.