### PR TITLE
[BUGS-6934] Gracefully handle archive pages with multiple post types

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 ## Changelog ##
 ### 1.4.2-dev ###
 * Updates Pantheon WP Coding Standards to 2.0 [[#249](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/249)]
+* Fixes an issue where a PHP warning was thrown when surrogate keys were emitted from archive pages with multiple post types. [[#252](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/252)]
 
 ### 1.4.1 ###
 * Send the REST API response header to the result and not the REST server [[#237](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/237)]. Props [@srtfisher](https://github.com/srtfisher) & [@felixarntz](https://github.com/felixarntz).

--- a/inc/class-emitter.php
+++ b/inc/class-emitter.php
@@ -281,7 +281,15 @@ class Emitter {
 			$keys[] = 'archive';
 			if ( is_post_type_archive() ) {
 				$keys[] = 'post-type-archive';
-				$keys[] = get_query_var( 'post_type' ) . '-archive';
+				$post_types = get_query_var( 'post_type' );
+				// If multiple post types are queried, create a surrogate key for each.
+				if ( is_array( $post_types ) ) {
+					foreach ( $post_types as $post_type ) {
+						$keys[] = "$post_type-archive";
+					}
+				} else {
+					$keys[] = "$post_types-archive";
+				}
 			} elseif ( is_author() ) {
 				$user_id = get_queried_object_id();
 				if ( $user_id ) {

--- a/readme.txt
+++ b/readme.txt
@@ -315,6 +315,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/mast
 == Changelog ==
 = 1.4.2-dev =
 * Updates Pantheon WP Coding Standards to 2.0 [[#249](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/249)]
+* Fixes an issue where a PHP warning was thrown when surrogate keys were emitted from archive pages with multiple post types. [[#252](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/252)]
 
 = 1.4.1 =
 * Send the REST API response header to the result and not the REST server [[#237](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/237)]. Props [@srtfisher](https://github.com/srtfisher) & [@felixarntz](https://github.com/felixarntz).

--- a/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
+++ b/tests/phpunit/class-pantheon-advanced-page-cache-testcase.php
@@ -8,6 +8,18 @@
 use Pantheon_Advanced_Page_Cache\Emitter;
 
 /**
+ * Declare our own factory class to avoid a PHP 8.0 deprecation warning.
+ */
+class Pantheon_WP_UnitTest_Factory extends WP_UnitTest_Factory {
+    public $product_category;
+
+    public function __construct() {
+        parent::__construct();
+        $this->product_category = new WP_UnitTest_Factory_For_Term($this, 'product_category');
+    }
+}
+
+/**
  * Class from which all tests inherit.
  */
 #[AllowDynamicProperties]
@@ -32,6 +44,8 @@ class Pantheon_Advanced_Page_Cache_Testcase extends WP_UnitTestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		// Use our own factory class to avoid a PHP 8.0 deprecation warning.
+		$this->factory = new Pantheon_WP_UnitTest_Factory();
 
 		$this->factory->product_category = new WP_UnitTest_Factory_For_Term( $this->factory, 'product_category' );
 

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -632,11 +632,11 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 		global $wp_query;
 
 		// Set up posts of different post types.
-		$this->factory->post->create( [
+		$product_id = $this->factory->post->create( [
 			'post_type' => 'product',
 			'post_title' => 'test product'
 		] );
-		$this->factory->post->create( [
+		$post_id = $this->factory->post->create( [
 			'post_type' => 'post',
 			'post_title' => 'test post'
 		] );
@@ -651,7 +651,15 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 
 		// Ensure that we don't get a WP Error from the surrogate key generator. This is a bit superfluous since if there was an error, we'd see it in the tests.
 		$this->assertTrue( ! is_wp_error( Emitter::get_main_query_surrogate_keys() ) );
-
+		// Make sure our newly-created posts are in the list of surrogate keys.
+		$this->assertContains(
+			"post-$post_id",
+			Emitter::get_main_query_surrogate_keys()
+		);
+		$this->assertContains(
+			"post-$product_id",
+			Emitter::get_main_query_surrogate_keys()
+		);
 		// Test that we have surrogate keys for the post and product we created.
 		if ( is_multisite() ) {
 			$this->assertContains(

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -651,15 +651,6 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 
 		// Ensure that we don't get a WP Error from the surrogate key generator. This is a bit superfluous since if there was an error, we'd see it in the tests.
 		$this->assertTrue( ! is_wp_error( Emitter::get_main_query_surrogate_keys() ) );
-		// Make sure our newly-created posts are in the list of surrogate keys.
-		$this->assertContains(
-			"post-$post_id",
-			Emitter::get_main_query_surrogate_keys()
-		);
-		$this->assertContains(
-			"post-$product_id",
-			Emitter::get_main_query_surrogate_keys()
-		);
 
 		// Test that we have surrogate keys for the post and product archives.
 		$wpms_prefix = '';
@@ -674,6 +665,16 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 		);
 		$this->assertContains(
 			$product_archive_key,
+			Emitter::get_main_query_surrogate_keys()
+		);
+
+		// Make sure our newly-created posts are in the list of surrogate keys.
+		$this->assertContains(
+			$wpms_prefix . "post-$post_id",
+			Emitter::get_main_query_surrogate_keys()
+		);
+		$this->assertContains(
+			$wpms_prefix . "post-$product_id",
 			Emitter::get_main_query_surrogate_keys()
 		);
 		wp_reset_query( $wp_query );

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -653,14 +653,25 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 		$this->assertTrue( ! is_wp_error( Emitter::get_main_query_surrogate_keys() ) );
 
 		// Test that we have surrogate keys for the post and product we created.
-		$this->assertContains(
-			'post-archive',
-			Emitter::get_main_query_surrogate_keys()
-		);
-		$this->assertContains(
-			'product-archive',
-			Emitter::get_main_query_surrogate_keys()
-		);
+		if ( is_multisite() ) {
+			$this->assertContains(
+				'blog-1-post-archive',
+				Emitter::get_main_query_surrogate_keys()
+			);
+			$this->assertContains(
+				'blog-1-product-archive',
+				Emitter::get_main_query_surrogate_keys()
+			);
+		} else {
+			$this->assertContains(
+				'post-archive',
+				Emitter::get_main_query_surrogate_keys()
+			);
+			$this->assertContains(
+				'product-archive',
+				Emitter::get_main_query_surrogate_keys()
+			);
+		}
 		wp_reset_query( $wp_query );
 	}
 }

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -633,7 +633,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 
 		// Set up posts of different post types.
 		$this->factory->post->create( [
-			'post_type' => 'post',
+			'post_type' => 'product',
 			'post_title' => 'test product'
 		] );
 		$this->factory->post->create( [

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -624,7 +624,7 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
-	 * Test that queries on archive pages with multiple post types doesn't throw an error.
+	 * Test that queries on archive pages with multiple post types don't throw an error.
 	 *
 	 * @see https://getpantheon.atlassian.net/browse/BUGS-6934
 	 */

--- a/tests/phpunit/test-emitter.php
+++ b/tests/phpunit/test-emitter.php
@@ -660,26 +660,22 @@ class Test_Emitter extends Pantheon_Advanced_Page_Cache_Testcase {
 			"post-$product_id",
 			Emitter::get_main_query_surrogate_keys()
 		);
-		// Test that we have surrogate keys for the post and product we created.
+
+		// Test that we have surrogate keys for the post and product archives.
+		$wpms_prefix = '';
 		if ( is_multisite() ) {
-			$this->assertContains(
-				'blog-1-post-archive',
-				Emitter::get_main_query_surrogate_keys()
-			);
-			$this->assertContains(
-				'blog-1-product-archive',
-				Emitter::get_main_query_surrogate_keys()
-			);
-		} else {
-			$this->assertContains(
-				'post-archive',
-				Emitter::get_main_query_surrogate_keys()
-			);
-			$this->assertContains(
-				'product-archive',
-				Emitter::get_main_query_surrogate_keys()
-			);
+			$wpms_prefix = 'blog-1-';
 		}
+		$post_archive_key = $wpms_prefix . 'post-archive';
+		$product_archive_key = $wpms_prefix . 'product-archive';
+		$this->assertContains(
+			$post_archive_key,
+			Emitter::get_main_query_surrogate_keys()
+		);
+		$this->assertContains(
+			$product_archive_key,
+			Emitter::get_main_query_surrogate_keys()
+		);
 		wp_reset_query( $wp_query );
 	}
 }


### PR DESCRIPTION
This PR resolves the issue where archive pages with multiple post types throws a PHP array to string conversion warning.

`get_query_var` can return an array or a string, depending on the query. Previously we were assuming `get_query_var( 'post_type' )` would only ever return a string. Most of the time this would be true, but there are cases where it is not. 

This PR adds tests against this scenario and adds handling that runs a `is_array` check on `get_query_var( 'post_type' )` and if it _is_ an array, emits surrogate keys for each post type.

this PR also creates a new Factory that extends the base WP Unit Test factory to avoid dynamically creating it and throwing PHP 8 deprecation warnings.