### PR TITLE
[CMSP-721] Bump Tested up to and echo PHP Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 4.7  
-**Tested up to:** 6.3  
+**Tested up to:** 6.4.1  
 **Stable tag:** 1.4.3-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -53,7 +53,7 @@ cd $BASH_DIR/..
 rsync -av --exclude='node_modules/' --exclude='vendor/' --exclude='tests/' ./* $PREPARE_DIR/wp-content/plugins/pantheon-advanced-page-cache
 rm -rf $PREPARE_DIR/wp-content/plugins/pantheon-advanced-page-cache/.git
 
-PHP_VERSION="$(terminus connection:info $SITE_ENV --field=php_version)"
+PHP_VERSION="$(terminus env:info $SITE_ENV --field=php_version)"
 echo "PHP Version: $PHP_VERSION"
 
 ###

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -53,6 +53,9 @@ cd $BASH_DIR/..
 rsync -av --exclude='node_modules/' --exclude='vendor/' --exclude='tests/' ./* $PREPARE_DIR/wp-content/plugins/pantheon-advanced-page-cache
 rm -rf $PREPARE_DIR/wp-content/plugins/pantheon-advanced-page-cache/.git
 
+PHP_VERSION="$(terminus connection:info $SITE_ENV --field=php_version)"
+echo "PHP Version: $PHP_VERSION"
+
 ###
 # Push files to the environment
 ###

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler
 Tags: pantheon, cdn, cache
 Requires at least: 4.7
-Tested up to: 6.3
+Tested up to: 6.4.1
 Stable tag: 1.4.3-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
So we can ensure Behat tests are run on a PHP 8.3 environment.

These Behat tests should pass because New Relic is not active on the CI fixture environment.