### PR TITLE
[CMSP-964] fix readme formatting

### DIFF
--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -24,7 +24,7 @@ jobs:
           shopt -s nocasematch
           run_plugin_update="true"
           for file in ${{ steps.get-changed-files.outputs.all }}; do
-            if [[ ! "$file" =~ ^\.wordpress\.org/ ]] && [[ "$file" != "readme.txt" ]]; then
+            if [[ ! "$file" =~ ^\.wordpress\.org/ ]] && [[ "$file" != "readme.txt" ]] && [[ $file != "readme.md" ]] && [[ $file =~ ^\.github/ ]]; then
               run_plugin_update="false"
               break
             fi

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -21,6 +21,7 @@ jobs:
       - id: set-outputs
         run: |
           echo "Changed files: ${{ steps.get-changed-files.outputs.all }}"
+          shopt -s nocasematch
           run_plugin_update="true"
           for file in ${{ steps.get-changed-files.outputs.all }}; do
             if [[ ! "$file" =~ ^\.wordpress\.org/ ]] && [[ "$file" != "readme.txt" ]]; then

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -9,7 +9,39 @@ permissions:
   contents: write
 
 jobs:
+  check-status:
+    runs-on: ubuntu-latest
+    outputs:
+      run-plugin-update: ${{ steps.set-outputs.outputs.run-plugin-update }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: get-changed-files
+        uses: jitterbit/get-changed-files@v1
+      - id: set-outputs
+        run: |
+          echo "Changed files: ${{ steps.get-changed-files.outputs.all }}"
+          run_plugin_update="true"
+          for file in ${{ steps.get-changed-files.outputs.all }}; do
+            if [[ ! "$file" =~ ^\.wordpress\.org/ ]] && [[ "$file" != "readme.txt" ]]; then
+              run_plugin_update="false"
+              break
+            fi
+          done
+          echo "::set-output name=run-plugin-update::$run_plugin_update"
+  asset-only:
+    needs: check-status
+    if: ${{ needs.check-status.outputs.run-plugin-update == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: WP.org Asset Only Update
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
   tag:
+    needs: check-status
+    if: ${{ needs.check-status.outputs.run-plugin-update == 'false' }}
     name: Create Tag and Draft Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   check-status:
+    name: Check Status
     runs-on: ubuntu-latest
     outputs:
       run-plugin-update: ${{ steps.set-outputs.outputs.run-plugin-update }}
@@ -29,6 +30,7 @@ jobs:
           done
           echo "::set-output name=run-plugin-update::$run_plugin_update"
   asset-only:
+    name: WP.org Asset Only Update
     needs: check-status
     if: ${{ needs.check-status.outputs.run-plugin-update == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Check Status
     runs-on: ubuntu-latest
     outputs:
-      run-plugin-update: ${{ steps.set-outputs.outputs.run-plugin-update }}
+      is-asset-update: ${{ steps.set-outputs.outputs.is-asset-update }}
     steps:
       - uses: actions/checkout@v4
       - id: get-changed-files
@@ -29,11 +29,11 @@ jobs:
               break
             fi
           done
-          echo "::set-output name=run-plugin-update::$run_plugin_update"
+          echo "::set-output name=is-asset-update::$run_plugin_update"
   asset-only:
     name: WP.org Asset Only Update
     needs: check-status
-    if: ${{ needs.check-status.outputs.run-plugin-update == 'true' }}
+    if: ${{ needs.check-status.outputs.is-asset-update == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
   tag:
     needs: check-status
-    if: ${{ needs.check-status.outputs.run-plugin-update == 'false' }}
+    if: ${{ needs.check-status.outputs.is-asset-update == 'false' }}
     name: Create Tag and Draft Release
     runs-on: ubuntu-latest
     steps:

--- a/readme.txt
+++ b/readme.txt
@@ -135,20 +135,18 @@ Need a bit more power? In addition to `pantheon_wp_clear_edge_keys()`, there are
 
 By default, Pantheon Advanced Page Cache is pretty aggressive in how it clears its surrogate keys. Specifically, any time `wp_insert_post` is called (which can include any time a post of any type is added or updated, even private post types), it will purge a variety of keys including `home`, `front`, `404` and `feed`. To bypass or override this behavior, since 1.5.0 we have a filter allowing an array of post types to ignore to be passed before those caches are purged. By default, the `revision` post type is ignored, but others can be added:
 
-```php
-/**
- * Add a custom post type to the ignored post types.
- *
- * @param array $ignored_post_types The array of ignored post types.
- * @return array
- */
-function filter_ignored_posts( $ignored_post_types ) {
-	$ignored_post_types[] = 'my-post-type'; // Ignore my-post-type from cache purges.
-	return $ignored_post_types;
-}
+	/**
+	* Add a custom post type to the ignored post types.
+	*
+	* @param array $ignored_post_types The array of ignored post types.
+	* @return array
+	*/
+	function filter_ignored_posts( $ignored_post_types ) {
+		$ignored_post_types[] = 'my-post-type'; // Ignore my-post-type from cache purges.
+		return $ignored_post_types;
+	}
 
-add_filter( 'pantheon_purge_post_type_ignored', 'filter_ignored_posts' );
-```
+	add_filter( 'pantheon_purge_post_type_ignored', 'filter_ignored_posts' );
 
 This will prevent the cache from being purged if the given post type is updated.
 


### PR DESCRIPTION
Removes the Markdown syntax ```php tag from the readme.txt.

Also adds a new workflow that allows for asset-only updates.