### PR TITLE
[CMSP-995] one more notice

### DIFF
--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -148,8 +148,9 @@ function admin_notice_maybe_recommend_higher_max_age() {
 	) {
 		$message = sprintf(
 			// translators: %s is a link to the Pantheon GCDN configuration page.
-			__( 'Your site\'s cache max-age is set below the recommendation (1 week). Visit the <a href="%s">Pantheon GCDN configuration page</a> to update the setting.' ),
-			admin_url( 'options-general.php?page=pantheon-cache' )
+			__( 'Your site\'s cache max-age is set below the recommendation (1 week). Visit the <a href="%1$s">Pantheon GCDN configuration page</a> to update the setting.%2$s' ),
+			admin_url( 'options-general.php?page=pantheon-cache' ),
+			sprintf( '<!-- Max Age Rank: %d -->', $max_age_rank )
 		);
 		$dismissable = false;
 		update_user_meta( get_current_user_id(), 'pantheon_max_age_global_warning_notice', true );

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -124,7 +124,6 @@ function admin_notice_maybe_recommend_higher_max_age() {
 
 	if (
 		$max_age_rank === 0 ||
-		$current_max_age >= WEEK_IN_SECONDS ||
 		$current_max_age === 600
 	) {
 		return;

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -130,11 +130,9 @@ function admin_notice_maybe_recommend_higher_max_age() {
 		$very_low = $max_age_rank > 3 ? __( 'This is a very low value and may not be optimal for your site.', 'pantheon-advanced-page-cache' ) : '';
 		$message = sprintf(
 			// translators: %1$s is the current max-age, %2$d is the current max-age in seconds, %3$s is a message that displays if the value is very low, %44d is the recommended max age in seconds, %5$s is the humanized recommended max age, %6$s is debug information that is written to the HTML DOM but not displayed.
-			__( 'The cache max-age is currently set to %1$s (%2$s seconds). %3$s Consider increasing the cache max-age to at least %4$d seconds (%5$s).%6$s', 'pantheon-advanced-page-cache' ),
+			__( 'The cache max-age is currently set to %1$s. %2$s Consider increasing the cache max-age to at least %3$s.%4$s', 'pantheon-advanced-page-cache' ),
 			humanized_max_age(),
-			$current_max_age,
 			$very_low,
-			WEEK_IN_SECONDS,
 			humanized_max_age( true ),
 			sprintf( '<!-- Max Age Rank: %d -->', $max_age_rank )
 		);

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -125,7 +125,8 @@ function admin_notice_maybe_recommend_higher_max_age() {
 		$max_age_rank > 0 &&
 		$current_max_age < WEEK_IN_SECONDS &&
 		$current_max_age !== 600 &&
-		isset( $current_screen->id ) && 'settings_page_pantheon-cache' === $current_screen->id
+		isset( $current_screen->id ) &&
+		'settings_page_pantheon-cache' === $current_screen->id
 		) {
 			// If the current max-age value has a rank of 3 or more (10 is the highest), we'll note that it's very low.
 		$very_low = $max_age_rank > 3 ? __( 'This is a very low value and may not be optimal for your site.', 'pantheon-advanced-page-cache' ) : '';
@@ -144,7 +145,7 @@ function admin_notice_maybe_recommend_higher_max_age() {
 		$max_age_rank > 0 &&
 		$current_max_age < WEEK_IN_SECONDS &&
 		$current_max_age !== 600 &&
-		! isset( $current_screen->id ) || 'settings_page_pantheon-cache' !== $current_screen->id
+		( ! isset( $current_screen->id ) || 'settings_page_pantheon-cache' !== $current_screen->id )
 	) {
 		$message = sprintf(
 			// translators: %s is a link to the Pantheon GCDN configuration page.

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -122,7 +122,11 @@ function admin_notice_maybe_recommend_higher_max_age() {
 	$max_age_rank = max_age_compare();
 	$current_max_age = get_current_max_age();
 
-	if ( $max_age_rank === 0 || $current_max_age === 600 ) {
+	// Check if the max-age rank is acceptable or if current max-age is 600 seconds and we haven't yet reset it to the default.
+	if (
+		$max_age_rank === 0 ||
+		( $current_max_age === 600 && ! get_option( 'pantheon_max_age_updated', false ) )
+	) {
 		return;
 	}
 

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -422,6 +422,10 @@ function max_age_updated_admin_notice() {
 		]
 	);
 
+	if ( ! $max_age_updated ) {
+		return;
+	}
+
 	// Update the user meta to prevent this notice from showing again after they've seen it once.
 	update_user_meta( $current_user_id, 'pantheon_max_age_updated_notice', true );
 }

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -121,13 +121,16 @@ function admin_notice_maybe_recommend_higher_max_age() {
 	$dismissable = true;
 	$max_age_rank = max_age_compare();
 	$current_max_age = get_current_max_age();
+
 	if (
-		$max_age_rank > 0 &&
-		$current_max_age < WEEK_IN_SECONDS &&
-		$current_max_age !== 600 &&
-		isset( $current_screen->id ) &&
-		'settings_page_pantheon-cache' === $current_screen->id
-		) {
+		$max_age_rank === 0 ||
+		$current_max_age >= WEEK_IN_SECONDS ||
+		$current_max_age === 600
+	 ) {
+		return;
+	 }
+
+	if ( isset( $current_screen->id ) && 'settings_page_pantheon-cache' === $current_screen->id ) {
 			// If the current max-age value has a rank of 3 or more (10 is the highest), we'll note that it's very low.
 		$very_low = $max_age_rank > 3 ? __( 'This is a very low value and may not be optimal for your site.', 'pantheon-advanced-page-cache' ) : '';
 		$message = sprintf(
@@ -141,12 +144,7 @@ function admin_notice_maybe_recommend_higher_max_age() {
 	}
 
 	// Global notice on all pages _except_ the Pantheon cache settings page.
-	if (
-		$max_age_rank > 0 &&
-		$current_max_age < WEEK_IN_SECONDS &&
-		$current_max_age !== 600 &&
-		( ! isset( $current_screen->id ) || 'settings_page_pantheon-cache' !== $current_screen->id )
-	) {
+	if ( ! isset( $current_screen->id ) || 'settings_page_pantheon-cache' !== $current_screen->id ) {
 		$message = sprintf(
 			// translators: %s is a link to the Pantheon GCDN configuration page.
 			__( 'Your site\'s cache max-age is set below the recommendation (1 week). Visit the <a href="%1$s">Pantheon GCDN configuration page</a> to update the setting.%2$s' ),

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -111,19 +111,22 @@ function admin_notice_old_mu_plugin() {
  */
 function admin_notice_maybe_recommend_higher_max_age() {
 	$current_screen = get_current_screen();
+	$global_warning_shown = current_user_can( 'manage_options' ) ? get_user_meta( get_current_user_id(), 'pantheon_max_age_global_warning_notice', true ) : true;
 
-	if ( apply_filters( 'pantheon_apc_disable_admin_notices', false, __FUNCTION__ ) || 'settings_page_pantheon-cache' !== $current_screen->id ) {
+	if ( apply_filters( 'pantheon_apc_disable_admin_notices', false, __FUNCTION__ ) || $global_warning_shown ) {
 		return;
 	}
 
+	$message = '';
 	$max_age_rank = max_age_compare();
 	$current_max_age = get_current_max_age();
 	if (
 		$max_age_rank > 0 &&
 		$current_max_age < WEEK_IN_SECONDS &&
-		$current_max_age !== 600
-	) {
-		// If the current max-age value has a rank of 3 or more (10 is the highest), we'll note that it's very low.
+		$current_max_age !== 600 &&
+		isset( $current_screen->id ) && 'settings_page_pantheon-cache' === $current_screen->id
+		) {
+			// If the current max-age value has a rank of 3 or more (10 is the highest), we'll note that it's very low.
 		$very_low = $max_age_rank > 3 ? __( 'This is a very low value and may not be optimal for your site.', 'pantheon-advanced-page-cache' ) : '';
 		$message = sprintf(
 			// translators: %1$s is the current max-age, %2$d is the current max-age in seconds, %3$s is a message that displays if the value is very low, %44d is the recommended max age in seconds, %5$s is the humanized recommended max age, %6$s is debug information that is written to the HTML DOM but not displayed.
@@ -135,7 +138,24 @@ function admin_notice_maybe_recommend_higher_max_age() {
 			humanized_max_age( true ),
 			sprintf( '<!-- Max Age Rank: %d -->', $max_age_rank )
 		);
+	}
 
+	// Global notice on all pages _except_ the Pantheon cache settings page.
+	if (
+		$max_age_rank > 0 &&
+		$current_max_age < WEEK_IN_SECONDS &&
+		$current_max_age !== 600 &&
+		! isset( $current_screen->id ) || 'settings_page_pantheon-cache' !== $current_screen->id
+	) {
+		$message = sprintf(
+			// translators: %s is a link to the Pantheon GCDN configuration page.
+			__( 'Your site\'s cache max-age is set below the recommendation (1 week). Visit the <a href="%s">Pantheon GCDN configuration page</a> to update the setting.' ),
+			admin_url( 'options-general.php?page=pantheon-cache' )
+		);
+		update_user_meta( get_current_user_id(), 'pantheon_max_age_global_warning_notice', true );
+	}
+
+	if ( ! empty( $message ) ) {
 		// Escalating notice types based on the max-age rank.
 		$notice_type = ( $max_age_rank === 1 ? 'info' : $max_age_rank > 3 ) ? 'error' : 'warning';
 

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -118,6 +118,7 @@ function admin_notice_maybe_recommend_higher_max_age() {
 	}
 
 	$message = '';
+	$dismissable = true;
 	$max_age_rank = max_age_compare();
 	$current_max_age = get_current_max_age();
 	if (
@@ -150,6 +151,7 @@ function admin_notice_maybe_recommend_higher_max_age() {
 			__( 'Your site\'s cache max-age is set below the recommendation (1 week). Visit the <a href="%s">Pantheon GCDN configuration page</a> to update the setting.' ),
 			admin_url( 'options-general.php?page=pantheon-cache' )
 		);
+		$dismissable = false;
 		update_user_meta( get_current_user_id(), 'pantheon_max_age_global_warning_notice', true );
 	}
 
@@ -161,7 +163,7 @@ function admin_notice_maybe_recommend_higher_max_age() {
 			$message,
 			[
 				'type' => $notice_type,
-				'dismissible' => true,
+				'dismissible' => $dismissable,
 			]
 		);
 	}

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -122,10 +122,7 @@ function admin_notice_maybe_recommend_higher_max_age() {
 	$max_age_rank = max_age_compare();
 	$current_max_age = get_current_max_age();
 
-	if (
-		$max_age_rank === 0 ||
-		$current_max_age === 600
-	) {
+	if ( $max_age_rank === 0 || $current_max_age === 600 ) {
 		return;
 	}
 

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -126,9 +126,9 @@ function admin_notice_maybe_recommend_higher_max_age() {
 		$max_age_rank === 0 ||
 		$current_max_age >= WEEK_IN_SECONDS ||
 		$current_max_age === 600
-	 ) {
+	) {
 		return;
-	 }
+	}
 
 	if ( isset( $current_screen->id ) && 'settings_page_pantheon-cache' === $current_screen->id ) {
 			// If the current max-age value has a rank of 3 or more (10 is the highest), we'll note that it's very low.

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -22,7 +22,8 @@ Scenario: Change the cache max age to 5 days
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "432000"
 	And I press "Save Changes"
-	Then I should see "Consider increasing the cache max-age to at least 1 week" in the ".notice" element
+	Then I should see "The cache max-age is currently set to 5 days" in the ".notice" element
+	And I should see "Consider increasing the cache max-age to at least 1 week" in the ".notice" element
 
 Scenario: Change the cache max age to 1 week
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -23,8 +23,6 @@ Scenario: Change the cache max age to 5 days
 	And I fill in "pantheon-cache[default_ttl]" with "432000"
 	And I press "Save Changes"
 	Then the "pantheon-cache[default_ttl]" field should contain "432000"
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	Then I should see "The cache max-age is currently set to 5 days"
 	And I should see "Consider increasing the cache max-age to at least 1 week"
 
 Scenario: Change the cache max age to 1 week

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -23,10 +23,10 @@ Scenario: Change the cache max age to 5 days
 	And I fill in "pantheon-cache[default_ttl]" with "432000"
 	And I press "Save Changes"
 	And I go to "/wp-admin/index.php"
-	Then I should see "Your site's cache max-age is set below the recommendation (1 week)." in the ".notice" element
+	Then I should see "Your site's cache max-age is set below the recommendation (1 week)."
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	Then I should see "The cache max-age is currently set to 5 days" in the ".notice" element
-	And I should see "Consider increasing the cache max-age to at least 1 week" in the ".notice" element
+	Then I should see "The cache max-age is currently set to 5 days"the ".notice" element
+	And I should see "Consider increasing the cache max-age to at least 1 week"
 
 Scenario: Change the cache max age to 1 week
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -18,13 +18,6 @@ Scenario: Change the cache max age
 	Then I should see "This is a very low value and may not be optimal for your site" in the ".notice" element
 	And I should see "Consider increasing the cache max-age to at least 1 week" in the ".notice" element
 
-Scenario: Change the cache max age to 5 days
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	And I fill in "pantheon-cache[default_ttl]" with "432000"
-	And I press "Save Changes"
-	Then the "pantheon-cache[default_ttl]" field should contain "432000"
-	And I should see "Consider increasing the cache max-age to at least 1 week"
-
 Scenario: Change the cache max age to 1 week
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "604800"

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -22,9 +22,7 @@ Scenario: Change the cache max age to 5 days
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "432000"
 	And I press "Save Changes"
-	And I go to "/wp-admin/index.php"
-	Then I should see "Your site's cache max-age is set below the recommendation (1 week)."
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
+	And I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	Then I should see "The cache max-age is currently set to 5 days"
 	And I should see "Consider increasing the cache max-age to at least 1 week"
 

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -22,6 +22,9 @@ Scenario: Change the cache max age to 5 days
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "432000"
 	And I press "Save Changes"
+	And I go to "/wp-admin/index.php"
+	Then I should see "Your site's cache max-age is set below the recommendation (1 week)." in the ".notice" element
+	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	Then I should see "The cache max-age is currently set to 5 days" in the ".notice" element
 	And I should see "Consider increasing the cache max-age to at least 1 week" in the ".notice" element
 

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -22,7 +22,8 @@ Scenario: Change the cache max age to 5 days
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "432000"
 	And I press "Save Changes"
-	And I go to "/wp-admin/options-general.php?page=pantheon-cache"
+	Then the "pantheon-cache[default_ttl]" field should contain "432000"
+	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	Then I should see "The cache max-age is currently set to 5 days"
 	And I should see "Consider increasing the cache max-age to at least 1 week"
 

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -25,7 +25,7 @@ Scenario: Change the cache max age to 5 days
 	And I go to "/wp-admin/index.php"
 	Then I should see "Your site's cache max-age is set below the recommendation (1 week)."
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	Then I should see "The cache max-age is currently set to 5 days"the ".notice" element
+	Then I should see "The cache max-age is currently set to 5 days"
 	And I should see "Consider increasing the cache max-age to at least 1 week"
 
 Scenario: Change the cache max age to 1 week

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -16,13 +16,13 @@ Scenario: Change the cache max age
 	And I fill in "pantheon-cache[default_ttl]" with "300"
 	And I press "Save Changes"
 	Then I should see "This is a very low value and may not be optimal for your site" in the ".notice" element
-	And I should see "Consider increasing the cache max-age to at least 604800 seconds (1 week)" in the ".notice" element
+	And I should see "Consider increasing the cache max-age to at least 1 week" in the ".notice" element
 
 Scenario: Change the cache max age to 5 days
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "432000"
 	And I press "Save Changes"
-	Then I should see "Consider increasing the cache max-age to at least 604800 seconds (1 week)" in the ".notice" element
+	Then I should see "Consider increasing the cache max-age to at least 1 week" in the ".notice" element
 
 Scenario: Change the cache max age to 1 week
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -288,4 +288,22 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		$this->assertStringContainsString( 'Your site\'s cache max-age is set below the recommendation (1 week).' , $notice );
 		$this->assertEquals( 1, $notice_shown );
 	}
+
+	/**
+	 * Test that the user meta for the global admin notice is created.
+	 */
+	function test_low_max_age_admin_notice_user_meta_warning() {
+		// Switch to admin.
+		wp_set_current_user( 1 );
+		delete_user_meta( 1, 'pantheon_max_age_global_warning_notice' );
+		update_option( 'pantheon-cache', [ 'default_ttl' => 432000 ] );
+		ob_start();
+		admin_notice_maybe_recommend_higher_max_age();
+		$notice = ob_get_clean();
+
+		$notice_shown = get_user_meta( 1, 'pantheon_max_age_global_warning_notice', true );
+		$this->assertStringContainsString( 'notice-warning', $notice );
+		$this->assertStringContainsString( 'Your site\'s cache max-age is set below the recommendation (1 week).' , $notice );
+		$this->assertEquals( 1, $notice_shown );
+	}
 }

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -271,4 +271,20 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		// The user meta should have been updated in the process.
 		$this->assertEquals( 1, get_user_meta( $current_user_id, 'pantheon_max_age_updated_notice', true ) );
 	}
+
+	/**
+	 * Test that the user meta for the global admin notice is created.
+	 */
+	function test_low_max_age_admin_notice_user_meta() {
+		// Switch to admin.
+		wp_set_current_user( 1 );
+		delete_user_meta( 1, 'pantheon_max_age_global_warning_notice' );
+		ob_start();
+		admin_notice_maybe_recommend_higher_max_age();
+		$notice = ob_get_clean();
+
+		$notice_shown = get_user_meta( 1, 'pantheon_max_age_global_warning_notice', true );
+		$this->assertStringContainsString( 'Your site\'s cache max-age is set below the recommendation (1 week).' , $notice );
+		$this->assertEquals( 1, $notice_shown );
+	}
 }

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -284,6 +284,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		$notice = ob_get_clean();
 
 		$notice_shown = get_user_meta( 1, 'pantheon_max_age_global_warning_notice', true );
+		$this->assertStringContainsString( 'notice-error', $notice );
 		$this->assertStringContainsString( 'Your site\'s cache max-age is set below the recommendation (1 week).' , $notice );
 		$this->assertEquals( 1, $notice_shown );
 	}


### PR DESCRIPTION
This PR adds another notice that appears globally (not just on the Pantheon Cache page) if your max-age value is less than the default. This notice goes away after you have seen it once. The type of the notice (error (red) or warning (yellow)) is determined by the `$max_age_rank` value, but the language of the notice does not change.

<img width="916" alt="Screenshot 2024-05-17 at 3 39 38 PM" src="https://github.com/pantheon-systems/pantheon-advanced-page-cache/assets/991511/bf19c3b0-255f-4f98-a10c-1bc83af799cf">
