### PR TITLE
Build unminified css

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,7 +20,7 @@
 /composer.lock export-ignore
 /CONTRIBUTING.md export-ignore
 /gulpfile.mjs export-ignore
-/package-lock.json export-ignore
+#/package-lock.json export-ignore
 /package.json export-ignore
 /phpcs.xml.dist export-ignore
 /phpunit.xml.dist export-ignore

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -4,6 +4,7 @@ on:
     paths:
       - 'composer.lock'
       - 'package-lock.json'
+      - '.github/workflows/composer-npm-diff.yml'
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           token: ${{ github.token }}
           updateComment: true
+          path: package-lock.json

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -30,6 +30,7 @@ jobs:
   npm-diff:
     name: NPM Lockfile Diff
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -40,3 +40,4 @@ jobs:
         with:
           token: ${{ github.token }}
           updateComment: true
+          path: package-lock.json

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -28,18 +28,20 @@ jobs:
             <strong>Composer Changes</strong>
 
             ${{ steps.composer_diff.outputs.composer_diff }}
-  npm-diff:
-    name: NPM Lockfile Diff
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Compile NPM packages
-        run: npm ci
-      - name: NPM Lockfile Changes
-        uses: codepunkt/npm-lockfile-changes@main
-        with:
-          token: ${{ github.token }}
+  # Removing because the workflow fails for some unknown reason, see https://github.com/pantheon-systems/pantheon-advanced-page-cache/actions/runs/9228002744/job/25391128483
+  # There's no support for this action, so we might need to build something new.
+            # npm-diff:
+  #   name: NPM Lockfile Diff
+  #   runs-on: ubuntu-latest
+  #   continue-on-error: true
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Compile NPM packages
+  #       run: npm ci
+  #     - name: NPM Lockfile Changes
+  #       uses: codepunkt/npm-lockfile-changes@main
+  #       with:
+  #         token: ${{ github.token }}

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -43,5 +43,3 @@ jobs:
         uses: codepunkt/npm-lockfile-changes@main
         with:
           token: ${{ github.token }}
-          updateComment: true
-          path: package-lock.json

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -42,3 +42,4 @@ jobs:
         with:
           token: ${{ github.token }}
           updateComment: true
+          path: ${{ github.workspace }}/package-lock.json

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -43,4 +43,3 @@ jobs:
         with:
           token: ${{ github.token }}
           updateComment: true
-          path: ${{ github.workspace }}/package-lock.json

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -40,4 +40,4 @@ jobs:
         with:
           token: ${{ github.token }}
           updateComment: true
-          path: package-lock.json
+          path: ${{ github.workspace }}/package-lock.json

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -3,8 +3,7 @@ on:
   pull_request:
     paths:
       - 'composer.lock'
-      - 'package-lock.json'
-      - '.github/workflows/composer-npm-diff.yml'
+    #  - 'package-lock.json'
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -35,9 +35,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Compile NPM packages
+        run: npm ci
       - name: NPM Lockfile Changes
         uses: codepunkt/npm-lockfile-changes@main
         with:
           token: ${{ github.token }}
           updateComment: true
-          path: ${{ github.workspace }}/package-lock.json

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -3,14 +3,17 @@ import gulp from 'gulp';
 import csso from 'gulp-csso';
 import * as sassCompiler from 'sass';
 import gulpSass from 'gulp-sass';
+import rename from 'gulp-rename'
 
 const sass = gulpSass(sassCompiler);
 
 gulp.task('styles', () => {
   return gulp.src('assets/sass/styles.scss') // Only compile the main file
     .pipe(sass().on('error', sass.logError)) // Compile SASS to CSS
+	.pipe(gulp.dest('assets/css')) // Save unminified CSS
     .pipe(csso()) // Minify CSS
-    .pipe(gulp.dest('assets/css')); // Save the CSS file
+	.pipe(rename({suffix: '.min'})) // Rename to styles.min.css
+    .pipe(gulp.dest('assets/css')); // Save the minified CSS file
 });
 
 gulp.task('clean', () => {

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -59,7 +59,9 @@ function enqueue_admin_assets() {
 
 	// If WP_DEBUG is true, append a timestamp to the end of the path so we get a fresh copy of the css.
 	$debug = defined( 'WP_DEBUG' ) && WP_DEBUG ? '-' . time() : '';
-	wp_enqueue_style( 'papc-admin', plugin_dir_url( __DIR__ ) . 'assets/css/styles.css', [], '2.0.0' . $debug );
+	// Use minified css unless SCRIPT_DEBUG is true.
+	$min = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+	wp_enqueue_style( 'papc-admin', plugin_dir_url( __DIR__ ) . "assets/css/styles$min.css", [], '2.0.0' . $debug );
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "gulp-autoprefixer": "^9.0.0",
         "gulp-concat": "^2.6.1",
         "gulp-csso": "^4.0.1",
+        "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
         "node-sass": "^9.0.0",
         "sass": "^1.77.1"
@@ -1883,6 +1884,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/gulp-rename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/gulp-sass": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gulp-autoprefixer": "^9.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-csso": "^4.0.1",
+    "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
     "node-sass": "^9.0.0",
     "sass": "^1.77.1"


### PR DESCRIPTION
[This report](https://github.com/pantheon-systems/pantheon-advanced-page-cache/actions/runs/9226233923/job/25385534617#step:3:334) from the WP.org validator is telling us that we need to include an uncompiled CSS file in addition to the compiled one we're shipping now. This would absolutely have been missed in every possible iteration of every PR or release until we actually went to tag something had I not manually added the css file to #270 to create an RC (so good that I did!).

This PR updates the Gulp workflow to create both an _unminified_ version as well as the minified version we're using now and renames the minified file to `styles.min.css`. An update is added to the `enqueue_admin_assets` function to call the minified version unless the `SCRIPT_DEBUG` constant is true.