### PR TITLE
Do not push to wporg on RC

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   release:
+    # Do not run this job for prerelease versions.
+    if: ! github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This adds a conditional check to the "Deploy to wp.org" workflow to check if the current release is a prerelease.

This came from ChatGPT as it seemed sus and I didn't want to do another pre-release that deployed to WP.org accidentally, but I was able to confirm that [`prerelease` is a bool in the GH API](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release), and there were a couple discussions on the official GH discussion board that referred to this solution ([this](https://github.com/orgs/community/discussions/42780#discussioncomment-8571958) and [this](https://github.com/orgs/community/discussions/26281)), which seems to indicate this is legit.