### PR TITLE
remove gitignore rule to ignore compiled css files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ Thumbs.db
 wp-cli.local.yml
 node_modules/
 vendor/
-assets/css/styles.css
-assets/css/*.css.map
 
 # wpunit helpers
 bin/helpers.sh


### PR DESCRIPTION
This gets in the way if css files need to be manually added or force pushed by automation and there's worse problems to have than just having compiled css files in the repository.