### PR TITLE
Fix syntax error in conditional in WP.org deploy workflow

### DIFF
--- a/.github/workflows/validate-actions-workflows.yml
+++ b/.github/workflows/validate-actions-workflows.yml
@@ -1,0 +1,26 @@
+name: Validate GitHub Actions workflows
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  validate-workflows:
+    name: Validate GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install action-validator with NPM
+        run: |
+          npm install -g @action-validator/core @action-validator/cli --save-dev
+          action-validator --help
+      - name: Validate workflows
+        run: |
+          # Loop over all the workflows in the .github/workflows directory.
+          for file in .github/workflows/*.yml; do
+            action-validator $file
+          done
+

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     # Do not run this job for prerelease versions.
-    if: ! github.event.release.prerelease
+    if: ${{ ! github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This fixes a syntax error in the conditional to check if a release is a pre-release.

This PR also adds a new GH actions workflow that validates our GH actions workflows to catch things like this in the future.