### PR TITLE
[BUGS-8452] add callback info to filtered message

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 6.4  
-**Tested up to:** 6.5.3  
+**Tested up to:** 6.6.1  
 **Stable tag:** 2.0.1-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -142,15 +142,27 @@ function get_pantheon_cache_filter_callback() {
  */
 function add_max_age_setting_description() {
 	$is_filtered = has_filter( 'pantheon_cache_default_max_age' );
+	$filter_callback = get_pantheon_cache_filter_callback();
+	$filtered_message = '';
 	$above_recommended_message = __( 'Your cache maximum age is currently <strong>above</strong> the recommended value.', 'pantheon-advanced-page-cache' );
 	$below_recommended_message = __( 'Your cache maximum age is currently <strong>below</strong> the recommended value.', 'pantheon-advanced-page-cache' );
 	$recommended_message = __( 'Your cache maximum age is currently set to the recommended value.', 'pantheon-advanced-page-cache' );
 	$recommendation_message = get_current_max_age() > WEEK_IN_SECONDS ? $above_recommended_message : ( get_current_max_age() < WEEK_IN_SECONDS ? $below_recommended_message : $recommended_message );
-	$filtered_message = $is_filtered ? sprintf(
-		// translators: %s is the humanized max-age.
-		__( 'This value has been hardcoded to %s via a filter.', 'pantheon-advanced-page-cache' ),
-		'<strong>' . humanized_max_age() . '</strong>'
-	) : '';
+
+	if ( $is_filtered ) {
+		// Set the message to name the callback(s).
+		$filtered_message = ! empty( $filter_callback ) ? sprintf(
+			// translators: %1$s is the humanized max-age, %2$s is the callback function(s).
+			__( 'This value has been hardcoded to %1$s via a filter hooked to %2$s in your code.', 'pantheon-advanced-page-cache' ),
+			'<strong>' . humanized_max_age() . '</strong>',
+			$filter_callback
+		) : sprintf(
+			// translators: %s is the humanized max-age.
+			__( 'This value has been hardcoded to %s via a filter.', 'pantheon-advanced-page-cache' ),
+			'<strong>' . humanized_max_age() . '</strong>'
+		); // If there's no callback, we'll just note that it's been hardcoded. This shouldn't ever happen.
+	}
+
 	$pantheon_cache = get_option( 'pantheon-cache', [] );
 	$has_custom_ttl = isset( $pantheon_cache['default_ttl'] ) && ! array_key_exists( $pantheon_cache['default_ttl'], max_age_options() );
 	$filtered_message .= $has_custom_ttl && ! $is_filtered ? '<br />' . __( '<strong>Warning:</strong>The cache max age is not one of the recommended values. If this is not intentional, you should remove this custom value and save the settings, then select one of the options from the dropdown.', 'pantheon-advanced-page-cache' ) : '';

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -87,6 +87,54 @@ function add_max_age_setting_header() {
 }
 
 /**
+ * Get the callback(s) hooked to pantheon_cache_default_max_age, if one exists.
+ *
+ * @since 2.1.0
+ * @return string
+ */
+function get_pantheon_cache_filter_callback() {
+	global $wp_filter;
+	$hook = 'pantheon_cache_default_max_age';
+	$output = '';
+
+	if ( ! has_filter( $hook ) ) {
+		return $output;
+	}
+
+	$callback_functions = [];
+	if ( isset( $wp_filter[ $hook ] ) ) {
+		foreach ( $wp_filter[ $hook ]->callbacks as $priority => $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_string( $callback['function'] ) ) {
+					// Function name.
+					$callback_functions[] = $callback['function'];
+				} elseif ( is_array( $callback['function'] ) ) {
+					// Method call.
+					$class = is_object( $callback['function'][0] ) ? get_class( $callback['function'][0] ) : $callback['function'][0];
+					$method = $callback['function'][1];
+					$callback_functions[] = "$class::$method";
+				} else {
+					$callback_functions[] = 'anonymous';
+				}
+			}
+		}
+	}
+
+	$callbacks_count = count( $callback_functions );
+	if ( $callbacks_count === 1 ) {
+		return "<code>{$callback_functions[0]}</code>";
+	}
+
+	// If there are multiple callbacks, format the output.
+	foreach ( $callback_functions as $index => $callback ) {
+		$callback = $callback === 'anonymous' ? __( 'an anonymous function', 'pantheon-advanced-page-cache' ) : "<code>$callback</code>";
+		$output .= $index === $callbacks_count - 1 ? ' ' . __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
+	}
+
+	return $output;
+}
+
+/**
  * Add a description to the max-age setting field.
  *
  * @since 2.0.0

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -114,7 +114,7 @@ function get_pantheon_cache_filter_callback() {
 					$method = $callback['function'][1];
 					$callback_functions[] = "$class::$method";
 				} else {
-					$callback_functions[] = 'anonymous';
+					$callback_functions[] = __( 'an anonymous function', 'pantheon-advanced-page-cache' );
 				}
 			}
 		}

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -128,8 +128,8 @@ function get_pantheon_cache_filter_callback() {
 
 	// If there are multiple callbacks, format the output.
 	foreach ( $callback_functions as $index => $callback ) {
-		$callback = $callback === 'anonymous' ? __( 'an anonymous function', 'pantheon-advanced-page-cache' ) : "<code>$callback</code>";
-		$output .= $index === $callbacks_count - 1 ? ' ' . __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
+		$callback = stripos( $callback, 'anonymous' ) !== false ? $callback : "<code>$callback</code>";
+		$output .= $index === $callbacks_count - 1 ? __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
 	}
 
 	return $output;

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -103,7 +103,7 @@ function get_pantheon_cache_filter_callback() {
 
 	$callback_functions = [];
 	if ( isset( $wp_filter[ $hook ] ) ) {
-		foreach ( $wp_filter[ $hook ]->callbacks as $priority => $callbacks ) {
+		foreach ( $wp_filter[ $hook ]->callbacks as $callbacks ) {
 			foreach ( $callbacks as $callback ) {
 				if ( is_string( $callback['function'] ) ) {
 					// Function name.

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -129,7 +129,7 @@ function get_pantheon_cache_filter_callback() {
 	// If there are multiple callbacks, format the output.
 	foreach ( $callback_functions as $index => $callback ) {
 		$callback = stripos( $callback, 'anonymous' ) !== false ? $callback : "<code>$callback</code>";
-		$output .= $index === $callbacks_count - 1 ? __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
+		$output .= $index === $callbacks_count - 1 ? __( 'and', 'pantheon-advanced-page-cache' ) . ' ' . $callback : $callback . ', ';
 	}
 
 	return $output;

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -120,9 +120,10 @@ function get_pantheon_cache_filter_callback() {
 		}
 	}
 
+	// Count the callbacks and if there's only one, return the name (if able).
 	$callbacks_count = count( $callback_functions );
 	if ( $callbacks_count === 1 ) {
-		return "<code>{$callback_functions[0]}</code>";
+		return stripos( $callback_functions[0], 'an anonymous function' ) === false ? "<code>{$callback_functions[0]}<code>" : $callback_functions[0];
 	}
 
 	// If there are multiple callbacks, format the output.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler
 Tags: pantheon, cdn, cache
 Requires at least: 6.4
-Tested up to: 6.5.3
+Tested up to: 6.6.1
 Stable tag: 2.0.1-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -353,6 +353,20 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
+	 * Filter callback for testing pantheon_cache_default_max_age.
+	 */
+	public function reset_cache_max_age() {
+		return 0;
+	}
+
+	/**
+	 * Filter callback for testing pantheon_cache_default_max_age.
+	 */
+	public function another_function() {
+		return 42;
+	}
+
+	/**
 	 * Test the update_default_ttl_input function. Check the input type if the max age has been filtered.
 	 *
 	 * @dataProvider update_default_ttl_input_provider

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -16,6 +16,10 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	private function get_five_minutes() {
 		$wp_version = get_bloginfo( 'version' );
+
+		// If the version contains a string like -alpha, -beta, etc., strip it.
+		$wp_version = preg_replace( '/-.*/', '', $wp_version );
+
 		// WordPress 6.7 changed the string for "5 mins" to "5 minutes".
 		$five_mins = version_compare( $wp_version, '6.7', '<' ) ? '5 mins' : '5 minutes';
 		return $five_mins;
@@ -112,6 +116,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function humanized_max_age_provider() {
 		$five_mins = $this->get_five_minutes();
+		var_dump( $five_mins );
 		return [
 			[ 300, $five_mins ], // 300 seconds is humanized to 5 mins.
 			[ 5 * DAY_IN_SECONDS, '5 days' ],

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -53,7 +53,8 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		$test_results = test_cache_max_age();
 		$this->assertEquals( 'recommended', $test_results['status'] );
 		$this->assertEquals( 'red',$test_results['badge']['color'] );
-		$this->assertStringContainsString( '5 mins', $test_results['description'] );
+		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
+		$this->assertStringContainsString( $five_mins, $test_results['description'] );
 		$this->assertStringContainsString( 'We recommend increasing to 1 week', $test_results['description'] );
 	}
 
@@ -99,8 +100,9 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 * @return array
 	 */
 	public function humanized_max_age_provider() {
+		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
 		return [
-			[ 300, '5 mins' ], // 300 seconds is humanized to 5 mins.
+			[ 300, $five_mins ], // 300 seconds is humanized to 5 mins.
 			[ 5 * DAY_IN_SECONDS, '5 days' ],
 			[ WEEK_IN_SECONDS, '1 week' ],
 		];

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -328,6 +328,14 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 			add_filter( 'pantheon_cache_default_max_age', function() {
 				return 10 * DAY_IN_SECONDS;
 			} );
+		} elseif ( $max_age === 'multiple-filters-below' ) {
+			add_filter( 'pantheon_cache_default_max_age', [ $this, 'reset_cache_max_age' ] );
+			add_filter( 'pantheon_cache_default_max_age', [ $this, 'another_function' ] );
+			add_filter( 'pantheon_cache_default_max_age', function() {
+				return 3 * DAY_IN_SECONDS;
+			} );
+		} elseif ( $max_age === 'just-named-filters' ) {
+			add_filter( 'pantheon_cache_default_max_age', [ $this, 'reset_cache_max_age' ] );
 		} else {
 			update_option( 'pantheon-cache', [ 'default_ttl' => $max_age ] );
 		}
@@ -343,8 +351,10 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function add_max_age_setting_description_provider() {
 		return [
-			[ 'filter-below', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>3 days</strong> via a filter.' ],
-			[ 'filter-above', 'Your cache maximum age is currently <strong>above</strong> the recommended value. This value has been hardcoded to <strong>1 week</strong> via a filter.' ],
+			[ 'filter-below', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>3 days</strong> via a filter hooked to an anonymous function in your code.' ],
+			[ 'filter-above', 'Your cache maximum age is currently <strong>above</strong> the recommended value. This value has been hardcoded to <strong>1 week</strong> via a filter hooked to an anonymous function in your code.' ],
+			[ 'multiple-filters-below', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>3 days</strong> via a filter hooked to <code>Pantheon_Advanced_Page_Cache\Admin_Interface\Admin_Interface_Functions::reset_cache_max_age</code>, <code>Pantheon_Advanced_Page_Cache\Admin_Interface\Admin_Interface_Functions::another_function</code>, and an anonymous function in your code.' ],
+			[ 'just-named-filters', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>1 second</strong> via a filter hooked to <code>Pantheon_Advanced_Page_Cache\Admin_Interface\Admin_Interface_Functions::reset_cache_max_age<code> in your code.' ],
 			[ 600, 'Your cache maximum age is currently <strong>below</strong> the recommended value. <br /><strong>Warning:</strong>The cache max age is not one of the recommended values.' ],
 			[ WEEK_IN_SECONDS, 'Your cache maximum age is currently set to the recommended value.' ],
 			[ MONTH_IN_SECONDS, 'Your cache maximum age is currently <strong>above</strong> the recommended value.' ],

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -12,6 +12,16 @@ namespace Pantheon_Advanced_Page_Cache\Admin_Interface;
  */
 class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	/**
+	 * Get the WordPress version-compatible string for "5 minutes".
+	 */
+	private function get_five_minutes() {
+		$wp_version = get_bloginfo( 'version' );
+		// WordPress 6.7 changed the string for "5 mins" to "5 minutes".
+		$five_mins = version_compare( $wp_version, '6.7', '<' ) ? '5 mins' : '5 minutes';
+		return $five_mins;
+	}
+
+	/**
 	 * Set up tests.
 	 */
 	public function setUp(): void {
@@ -46,6 +56,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function test_site_health_tests_300_seconds() {
 		$tests = apply_filters( 'site_status_tests', [] );
+		$five_mins = $this->get_five_minutes();
 
 		$this->assertContains( 'pantheon_edge_cache', array_keys( $tests['direct'] ) );
 
@@ -53,7 +64,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		$test_results = test_cache_max_age();
 		$this->assertEquals( 'recommended', $test_results['status'] );
 		$this->assertEquals( 'red',$test_results['badge']['color'] );
-		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
+
 		$this->assertStringContainsString( $five_mins, $test_results['description'] );
 		$this->assertStringContainsString( 'We recommend increasing to 1 week', $test_results['description'] );
 	}
@@ -100,7 +111,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 * @return array
 	 */
 	public function humanized_max_age_provider() {
-		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
+		$five_mins = $this->get_five_minutes();
 		return [
 			[ 300, $five_mins ], // 300 seconds is humanized to 5 mins.
 			[ 5 * DAY_IN_SECONDS, '5 days' ],


### PR DESCRIPTION
This pull request adds functionality to display the filter callback name(s) in the filtered message. It also handles anonymous functions and includes tests for the filter callbacks.

**Page Cache Max Age setting with named filter callback:**
<img width="1542" alt="Screenshot 2024-08-05 at 11 34 17 AM" src="https://github.com/user-attachments/assets/7389f7f2-1a33-4e9c-b543-c1938be8bad5">

**Page Cache Max Age setting with anonymous filter callback:**
<img width="1540" alt="Screenshot 2024-08-05 at 11 34 54 AM" src="https://github.com/user-attachments/assets/c373081f-a236-4c14-bffe-a9f8b5db8316">

**Page Cache Max Age setting with named and anonymous filter callback:**
<img width="1542" alt="Screenshot 2024-08-05 at 12 07 09 PM" src="https://github.com/user-attachments/assets/efc1296c-7d5b-4c1d-b835-f0a25b66db94">
