### PR TITLE
[BUGS-8452] remove `nonce_life` filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 6.4  
-**Tested up to:** 6.5.3  
+**Tested up to:** 6.6.1  
 **Stable tag:** 2.0.1-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pantheon Advanced Page Cache #
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)
-**Tags:** pantheon, cdn, cache
-**Requires at least:** 6.4
-**Tested up to:** 6.6.1
-**Stable tag:** 2.0.1-dev
-**License:** GPLv2 or later
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
+**Tags:** pantheon, cdn, cache  
+**Requires at least:** 6.4  
+**Tested up to:** 6.6.1  
+**Stable tag:** 2.0.1-dev  
+**License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Automatically clear related pages from Pantheon's Edge when you update content. High TTL. Fresh content. Visitors never wait.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pantheon Advanced Page Cache #
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
-**Tags:** pantheon, cdn, cache  
-**Requires at least:** 6.4  
-**Tested up to:** 6.6.1  
-**Stable tag:** 2.0.1-dev  
-**License:** GPLv2 or later  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)
+**Tags:** pantheon, cdn, cache
+**Requires at least:** 6.4
+**Tested up to:** 6.6.1
+**Stable tag:** 2.0.1-dev
+**License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Automatically clear related pages from Pantheon's Edge when you update content. High TTL. Fresh content. Visitors never wait.
@@ -177,19 +177,15 @@ When the cache max age is filtered in this way, the admin option is disabled and
 
 ![Page Cache Max Age with filtered value](.wordpress-org/screenshots/page-cache-max-age-filtered.png)
 
-### Setting the Cache Max Age with a filter
+### Updating the cache max age based on nonces
 
-The cache max age setting is controlled by the [Pantheon Page Cache](https://docs.pantheon.io/guides/wordpress-configurations/wordpress-cache-pluginhttps://docs.pantheon.io/guides/wordpress-configurations/wordpress-cache-plugin) admin page. As of 2.0.0, there are three cache age options by default — 1 week, 1 month, 1 year. Pantheon Advanced Page Cache automatically purges the cache of updated and related posts and pages, but you might want to override the cache max age value and set it programmatically. In this case, you can use the `pantheon_cache_default_max_age` filter added in [Pantheon MU plugin 1.4.0+](https://docs.pantheon.io/guides/wordpress-configurations/wordpress-cache-plugin#override-the-default-max-age). For example:
+Nonces created on the front-end, often used to secure forms and other data, have a lifetime, and if the cache max age is longer than the nonce lifetime, the nonce may expire before the cache does. To avoid this, you can use the `pantheon_cache_nonce_lifetime` action to set the `pantheon_cache_default_max_age` to less than the nonce lifetime. For example:
 
 ```php
-add_filter( 'pantheon_cache_default_max_age', function() {
-	return 10 * DAY_IN_SECONDS;
-} );
+do_action( 'pantheon_cache_nonce_lifetime' );
 ```
 
-When the cache max age is filtered in this way, the admin option is disabled and a notice is displayed.
-
-![Page Cache Max Age with filtered value](.wordpress-org/screenshots/page-cache-max-age-filtered.png)
+It's important to wrap your `do_action` in the appropriate conditionals to ensure that the action is only called when necessary and not filtering the cache max age in cases when it's not necessary. This might mean only running on certain pages or in certain contexts in your code.
 
 ## WP-CLI Commands ##
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -80,9 +80,6 @@ terminus wp $SITE_ENV -- cache flush
 terminus wp $SITE_ENV -- plugin activate pantheon-advanced-page-cache
 terminus wp $SITE_ENV -- theme activate twentytwentythree
 terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
-# Add the pantheon-cache option if it doesn't already exist.
-if ! terminus wp $SITE_ENV -- option get pantheon-cache; then
-  	terminus wp $SITE_ENV -- option add pantheon-cache '{"default_ttl":600,"maintenance_mode":"disabled"}' --format=json
-fi
-# Set the starting default_ttl value to 600, our old default.
-terminus wp $SITE_ENV -- option patch set pantheon-cache default_ttl 600
+# Add the pantheon-cache option. We're assuming it doesn't already exist.
+terminus wp $SITE_ENV -- option add pantheon-cache '{"default_ttl":600,"maintenance_mode":"disabled"}' --format=json
+

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -82,7 +82,7 @@ terminus wp $SITE_ENV -- theme activate twentytwentythree
 terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
 # Add the pantheon-cache option if it doesn't already exist.
 if ! terminus wp $SITE_ENV -- option get pantheon-cache; then
-  	terminus wp $SITE_ENV -- option add pantheon-cache
+  	terminus wp $SITE_ENV -- option add pantheon-cache '{"default_ttl":600,"maintenance_mode":"disabled"}' --format=json
 fi
 # Set the starting default_ttl value to 600, our old default.
 terminus wp $SITE_ENV -- option patch set pantheon-cache default_ttl 600

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -81,4 +81,4 @@ terminus wp $SITE_ENV -- plugin activate pantheon-advanced-page-cache
 terminus wp $SITE_ENV -- theme activate twentytwentythree
 terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
 # Set the starting default_ttl value to 600, our old default.
-terminus wp $SITE_ENV -- option patch update pantheon-cache default_ttl 600
+terminus wp $SITE_ENV -- option patch set pantheon-cache default_ttl 600

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -80,3 +80,5 @@ terminus wp $SITE_ENV -- cache flush
 terminus wp $SITE_ENV -- plugin activate pantheon-advanced-page-cache
 terminus wp $SITE_ENV -- theme activate twentytwentythree
 terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
+# Set the starting default_ttl value to 600, our old default.
+wp option patch update pantheon-cache default_ttl 600

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -81,4 +81,4 @@ terminus wp $SITE_ENV -- plugin activate pantheon-advanced-page-cache
 terminus wp $SITE_ENV -- theme activate twentytwentythree
 terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
 # Set the starting default_ttl value to 600, our old default.
-wp option patch update pantheon-cache default_ttl 600
+terminus wp $SITE_ENV -- option patch update pantheon-cache default_ttl 600

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -80,5 +80,9 @@ terminus wp $SITE_ENV -- cache flush
 terminus wp $SITE_ENV -- plugin activate pantheon-advanced-page-cache
 terminus wp $SITE_ENV -- theme activate twentytwentythree
 terminus wp $SITE_ENV -- rewrite structure '/%year%/%monthnum%/%day%/%postname%/'
+# Add the pantheon-cache option if it doesn't already exist.
+if ! terminus wp $SITE_ENV -- option get pantheon-cache; then
+  	terminus wp $SITE_ENV -- option add pantheon-cache
+fi
 # Set the starting default_ttl value to 600, our old default.
 terminus wp $SITE_ENV -- option patch set pantheon-cache default_ttl 600

--- a/composer.lock
+++ b/composer.lock
@@ -9,32 +9,32 @@
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd"
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
-                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/2b1d206d81b74ed999023cffd924f862ff2753c8",
+                "reference": "2b1d206d81b74ed999023cffd924f862ff2753c8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.1.0",
-                "phpcsstandards/phpcsutils": "^1.0.8",
-                "sirbrillig/phpcs-variable-analysis": "^2.11.17",
-                "squizlabs/php_codesniffer": "^3.7.2",
-                "wp-coding-standards/wpcs": "^3.0"
+                "phpcsstandards/phpcsextra": "^1.2.1",
+                "phpcsstandards/phpcsutils": "^1.0.11",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.18",
+                "squizlabs/php_codesniffer": "^3.9.2",
+                "wp-coding-standards/wpcs": "^3.1.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7 || ^8 || ^9"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -59,7 +59,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2023-09-05T11:01:05+00:00"
+            "time": "2024-05-10T20:31:09+00:00"
         },
         {
             "name": "behat/behat",
@@ -1077,16 +1077,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -1094,11 +1094,12 @@
             },
             "conflict": {
                 "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
                 "doctrine/collections": "^1.6.8",
                 "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
@@ -1124,7 +1125,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -1132,20 +1133,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-08T13:26:56+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.2",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
-                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
@@ -1156,7 +1157,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -1188,9 +1189,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-05T20:51:40+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "pantheon-systems/pantheon-wordpress-upstream-tests",
@@ -1198,12 +1199,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests.git",
-                "reference": "612d7d3e5ce064d7d30cc9752bc0e06d4a22f933"
+                "reference": "c925c382018d324919b10e5f1b1b46e5604a0396"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/pantheon-wordpress-upstream-tests/zipball/612d7d3e5ce064d7d30cc9752bc0e06d4a22f933",
-                "reference": "612d7d3e5ce064d7d30cc9752bc0e06d4a22f933",
+                "url": "https://api.github.com/repos/pantheon-systems/pantheon-wordpress-upstream-tests/zipball/c925c382018d324919b10e5f1b1b46e5604a0396",
+                "reference": "c925c382018d324919b10e5f1b1b46e5604a0396",
                 "shasum": ""
             },
             "require": {
@@ -1229,20 +1230,20 @@
                 "issues": "https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/issues",
                 "source": "https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/tree/master"
             },
-            "time": "2024-05-07T20:24:56+00:00"
+            "time": "2024-08-06T21:37:09+00:00"
         },
         {
             "name": "pantheon-systems/pantheon-wp-coding-standards",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards.git",
-                "reference": "dbaf18c76ab342d1979f304a3dae0b529750e4e2"
+                "reference": "5008d7416057ab0420bcddd407d9833340a0081d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/dbaf18c76ab342d1979f304a3dae0b529750e4e2",
-                "reference": "dbaf18c76ab342d1979f304a3dae0b529750e4e2",
+                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/5008d7416057ab0420bcddd407d9833340a0081d",
+                "reference": "5008d7416057ab0420bcddd407d9833340a0081d",
                 "shasum": ""
             },
             "require": {
@@ -1269,9 +1270,9 @@
             "description": "PHPCS Rulesets for WordPress projects on Pantheon.",
             "support": {
                 "issues": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/issues",
-                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/2.0.1"
+                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/2.0.3"
             },
-            "time": "2023-12-12T16:18:18+00:00"
+            "time": "2024-07-05T21:39:52+00:00"
         },
         {
             "name": "pantheon-systems/wpunit-helpers",
@@ -1721,22 +1722,22 @@
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.11",
+            "version": "1.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a"
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
-                "reference": "c457da9dabb60eb7106dd5e3c05132b1a6539c6a",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.9.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
             },
             "require-dev": {
                 "ext-filter": "*",
@@ -1805,20 +1806,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-24T11:47:18+00:00"
+            "time": "2024-05-20T13:34:27+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.29.0",
+            "version": "1.29.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "536889f2b340489d328f5ffb7b02bb6b183ddedc"
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/536889f2b340489d328f5ffb7b02bb6b183ddedc",
-                "reference": "536889f2b340489d328f5ffb7b02bb6b183ddedc",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fcaefacf2d5c417e928405b71b400d4ce10daaf4",
+                "reference": "fcaefacf2d5c417e928405b71b400d4ce10daaf4",
                 "shasum": ""
             },
             "require": {
@@ -1850,9 +1851,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
-            "time": "2024-05-06T12:04:23+00:00"
+            "time": "2024-05-31T08:52:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2175,45 +2176,45 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.19",
+            "version": "9.6.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8"
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a1a54a473501ef4cdeaae4e06891674114d79db8",
-                "reference": "a1a54a473501ef4cdeaae4e06891674114d79db8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/49d7820565836236411f5dc002d16dd689cde42f",
+                "reference": "49d7820565836236411f5dc002d16dd689cde42f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
+                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-code-coverage": "^9.2.31",
+                "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
                 "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.6",
+                "sebastian/global-state": "^5.0.7",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -2258,7 +2259,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.20"
             },
             "funding": [
                 {
@@ -2274,7 +2275,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-05T04:35:58+00:00"
+            "time": "2024-07-10T11:45:39+00:00"
         },
         {
             "name": "psr/container",
@@ -3436,16 +3437,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.18",
+            "version": "v2.11.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "ca242a0b7309e0f9d1f73b236e04ecf4ca3248d0"
+                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ca242a0b7309e0f9d1f73b236e04ecf4ca3248d0",
-                "reference": "ca242a0b7309e0f9d1f73b236e04ecf4ca3248d0",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
+                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
                 "shasum": ""
             },
             "require": {
@@ -3490,7 +3491,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2024-04-13T16:42:46+00:00"
+            "time": "2024-06-26T20:08:34+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -3559,16 +3560,16 @@
         },
         {
             "name": "spryker/code-sniffer",
-            "version": "0.17.23",
+            "version": "0.17.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/code-sniffer.git",
-                "reference": "1cb5550e11f25c200016d0d3cd7021b2dfeadaf5"
+                "reference": "c984469f785ba5aa347df041462511ee4c99c263"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/code-sniffer/zipball/1cb5550e11f25c200016d0d3cd7021b2dfeadaf5",
-                "reference": "1cb5550e11f25c200016d0d3cd7021b2dfeadaf5",
+                "url": "https://api.github.com/repos/spryker/code-sniffer/zipball/c984469f785ba5aa347df041462511ee4c99c263",
+                "reference": "c984469f785ba5aa347df041462511ee4c99c263",
                 "shasum": ""
             },
             "require": {
@@ -3613,20 +3614,20 @@
                 "issues": "https://github.com/spryker/code-sniffer/issues",
                 "source": "https://github.com/spryker/code-sniffer"
             },
-            "time": "2024-03-22T09:53:22+00:00"
+            "time": "2024-06-06T13:33:45+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.9.2",
+            "version": "3.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480"
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/aac1f6f347a5c5ac6bc98ad395007df00990f480",
-                "reference": "aac1f6f347a5c5ac6bc98ad395007df00990f480",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/86e5f5dd9a840c46810ebe5ff1885581c42a3017",
+                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017",
                 "shasum": ""
             },
             "require": {
@@ -3693,7 +3694,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-23T20:25:34+00:00"
+            "time": "2024-07-21T23:26:44+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -3847,16 +3848,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.39",
+            "version": "v5.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f3e591c48688a0cfa1a3296205926c05e84b22b1"
+                "reference": "cef62396a0477e94fc52e87a17c6e5c32e226b7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f3e591c48688a0cfa1a3296205926c05e84b22b1",
-                "reference": "f3e591c48688a0cfa1a3296205926c05e84b22b1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cef62396a0477e94fc52e87a17c6e5c32e226b7f",
+                "reference": "cef62396a0477e94fc52e87a17c6e5c32e226b7f",
                 "shasum": ""
             },
             "require": {
@@ -3926,7 +3927,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.39"
+                "source": "https://github.com/symfony/console/tree/v5.4.42"
             },
             "funding": [
                 {
@@ -3942,20 +3943,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-07-26T12:21:55+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.4.39",
+            "version": "v5.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "0934c9f1d433776f25c629bdc93f3e157d139e08"
+                "reference": "ea43887e9afd2029509662d4f95e8b5ef6fc9bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/0934c9f1d433776f25c629bdc93f3e157d139e08",
-                "reference": "0934c9f1d433776f25c629bdc93f3e157d139e08",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ea43887e9afd2029509662d4f95e8b5ef6fc9bbb",
+                "reference": "ea43887e9afd2029509662d4f95e8b5ef6fc9bbb",
                 "shasum": ""
             },
             "require": {
@@ -3992,7 +3993,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.4.39"
+                "source": "https://github.com/symfony/css-selector/tree/v5.4.40"
             },
             "funding": [
                 {
@@ -4008,7 +4009,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-05-31T14:33:22+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -4239,16 +4240,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.39",
+            "version": "v5.4.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d40fae9fd85c762b6ba378152fdd1157a85d7e4f"
+                "reference": "a54e2a8a114065f31020d6a89ede83e34c3b27a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d40fae9fd85c762b6ba378152fdd1157a85d7e4f",
-                "reference": "d40fae9fd85c762b6ba378152fdd1157a85d7e4f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a54e2a8a114065f31020d6a89ede83e34c3b27a4",
+                "reference": "a54e2a8a114065f31020d6a89ede83e34c3b27a4",
                 "shasum": ""
             },
             "require": {
@@ -4304,7 +4305,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.39"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.40"
             },
             "funding": [
                 {
@@ -4320,7 +4321,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-05-31T14:33:22+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -4400,23 +4401,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.39",
+            "version": "v5.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e6edd875d5d39b03de51f3c3951148cfa79a4d12"
+                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e6edd875d5d39b03de51f3c3951148cfa79a4d12",
-                "reference": "e6edd875d5d39b03de51f3c3951148cfa79a4d12",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6d29dd9340b372fa603f04e6df4dd76bb808591e",
+                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8",
-                "symfony/polyfill-php80": "^1.16",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "require-dev": {
                 "symfony/process": "^5.4|^6.4"
             },
             "type": "library",
@@ -4445,7 +4448,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.39"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.41"
             },
             "funding": [
                 {
@@ -4461,20 +4464,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T08:26:06+00:00"
+            "time": "2024-06-28T09:36:24+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
-                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
+                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
                 "shasum": ""
             },
             "require": {
@@ -4524,7 +4527,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -4540,20 +4543,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f"
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/32a9da87d7b3245e09ac426c83d334ae9f06f80f",
-                "reference": "32a9da87d7b3245e09ac426c83d334ae9f06f80f",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/64647a7c30b2283f5d49b874d84a18fc22054b7a",
+                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a",
                 "shasum": ""
             },
             "require": {
@@ -4602,7 +4605,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -4618,20 +4621,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919"
+                "reference": "a6e83bdeb3c84391d1dfe16f42e40727ce524a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a287ed7475f85bf6f61890146edbc932c0fff919",
-                "reference": "a287ed7475f85bf6f61890146edbc932c0fff919",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/a6e83bdeb3c84391d1dfe16f42e40727ce524a5c",
+                "reference": "a6e83bdeb3c84391d1dfe16f42e40727ce524a5c",
                 "shasum": ""
             },
             "require": {
@@ -4686,7 +4689,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -4702,20 +4705,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d"
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/bc45c394692b948b4d383a08d7753968bed9a83d",
-                "reference": "bc45c394692b948b4d383a08d7753968bed9a83d",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/a95281b0be0d9ab48050ebd988b967875cdb9fdb",
+                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb",
                 "shasum": ""
             },
             "require": {
@@ -4767,7 +4770,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -4783,20 +4786,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
-                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
                 "shasum": ""
             },
             "require": {
@@ -4847,7 +4850,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -4863,20 +4866,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25"
+                "reference": "10112722600777e02d2745716b70c5db4ca70442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/861391a8da9a04cbad2d232ddd9e4893220d6e25",
-                "reference": "861391a8da9a04cbad2d232ddd9e4893220d6e25",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/10112722600777e02d2745716b70c5db4ca70442",
+                "reference": "10112722600777e02d2745716b70c5db4ca70442",
                 "shasum": ""
             },
             "require": {
@@ -4920,7 +4923,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -4936,20 +4939,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "21bd091060673a1177ae842c0ef8fe30893114d2"
+                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/21bd091060673a1177ae842c0ef8fe30893114d2",
-                "reference": "21bd091060673a1177ae842c0ef8fe30893114d2",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/ec444d3f3f6505bb28d11afa41e75faadebc10a1",
+                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1",
                 "shasum": ""
             },
             "require": {
@@ -4996,7 +4999,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -5012,20 +5015,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
-                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
                 "shasum": ""
             },
             "require": {
@@ -5076,7 +5079,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -5092,20 +5095,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.29.0",
+            "version": "v1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d"
+                "reference": "3fb075789fb91f9ad9af537c4012d523085bd5af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/c565ad1e63f30e7477fc40738343c62b40bc672d",
-                "reference": "c565ad1e63f30e7477fc40738343c62b40bc672d",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/3fb075789fb91f9ad9af537c4012d523085bd5af",
+                "reference": "3fb075789fb91f9ad9af537c4012d523085bd5af",
                 "shasum": ""
             },
             "require": {
@@ -5152,7 +5155,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.29.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.30.0"
             },
             "funding": [
                 {
@@ -5168,68 +5171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-29T20:11:03+00:00"
-        },
-        {
-            "name": "symfony/process",
-            "version": "v6.4.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "cdb1c81c145fd5aa9b0038bab694035020943381"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/cdb1c81c145fd5aa9b0038bab694035020943381",
-                "reference": "cdb1c81c145fd5aa9b0038bab694035020943381",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Process\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Executes commands in sub-processes",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.7"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2024-06-19T12:30:46+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5316,16 +5258,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.7",
+            "version": "v6.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ffeb9591c61f65a68d47f77d12b83fa530227a69"
+                "reference": "ccf9b30251719567bfd46494138327522b9a9446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ffeb9591c61f65a68d47f77d12b83fa530227a69",
-                "reference": "ffeb9591c61f65a68d47f77d12b83fa530227a69",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ccf9b30251719567bfd46494138327522b9a9446",
+                "reference": "ccf9b30251719567bfd46494138327522b9a9446",
                 "shasum": ""
             },
             "require": {
@@ -5382,7 +5324,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.7"
+                "source": "https://github.com/symfony/string/tree/v6.4.10"
             },
             "funding": [
                 {
@@ -5398,7 +5340,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:22:46+00:00"
+            "time": "2024-07-22T10:21:14+00:00"
         },
         {
             "name": "symfony/translation",
@@ -5569,16 +5511,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.7",
+            "version": "v6.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "53e8b1ef30a65f78eac60fddc5ee7ebbbdb1dee0"
+                "reference": "52903de178d542850f6f341ba92995d3d63e60c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/53e8b1ef30a65f78eac60fddc5ee7ebbbdb1dee0",
-                "reference": "53e8b1ef30a65f78eac60fddc5ee7ebbbdb1dee0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/52903de178d542850f6f341ba92995d3d63e60c9",
+                "reference": "52903de178d542850f6f341ba92995d3d63e60c9",
                 "shasum": ""
             },
             "require": {
@@ -5621,7 +5563,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.7"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.8"
             },
             "funding": [
                 {
@@ -5637,7 +5579,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-28T10:28:08+00:00"
+            "time": "2024-05-31T14:49:08+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -142,15 +142,27 @@ function get_pantheon_cache_filter_callback() {
  */
 function add_max_age_setting_description() {
 	$is_filtered = has_filter( 'pantheon_cache_default_max_age' );
+	$filter_callback = get_pantheon_cache_filter_callback();
+	$filtered_message = '';
 	$above_recommended_message = __( 'Your cache maximum age is currently <strong>above</strong> the recommended value.', 'pantheon-advanced-page-cache' );
 	$below_recommended_message = __( 'Your cache maximum age is currently <strong>below</strong> the recommended value.', 'pantheon-advanced-page-cache' );
 	$recommended_message = __( 'Your cache maximum age is currently set to the recommended value.', 'pantheon-advanced-page-cache' );
 	$recommendation_message = get_current_max_age() > WEEK_IN_SECONDS ? $above_recommended_message : ( get_current_max_age() < WEEK_IN_SECONDS ? $below_recommended_message : $recommended_message );
-	$filtered_message = $is_filtered ? sprintf(
-		// translators: %s is the humanized max-age.
-		__( 'This value has been hardcoded to %s via a filter.', 'pantheon-advanced-page-cache' ),
-		'<strong>' . humanized_max_age() . '</strong>'
-	) : '';
+
+	if ( $is_filtered ) {
+		// Set the message to name the callback(s).
+		$filtered_message = ! empty( $filter_callback ) ? sprintf(
+			// translators: %1$s is the humanized max-age, %2$s is the callback function(s).
+			__( 'This value has been hardcoded to %1$s via a filter hooked to %2$s in your code.', 'pantheon-advanced-page-cache' ),
+			'<strong>' . humanized_max_age() . '</strong>',
+			$filter_callback
+		) : sprintf(
+			// translators: %s is the humanized max-age.
+			__( 'This value has been hardcoded to %s via a filter.', 'pantheon-advanced-page-cache' ),
+			'<strong>' . humanized_max_age() . '</strong>'
+		); // If there's no callback, we'll just note that it's been hardcoded. This shouldn't ever happen.
+	}
+
 	$pantheon_cache = get_option( 'pantheon-cache', [] );
 	$has_custom_ttl = isset( $pantheon_cache['default_ttl'] ) && ! array_key_exists( $pantheon_cache['default_ttl'], max_age_options() );
 	$filtered_message .= $has_custom_ttl && ! $is_filtered ? '<br />' . __( '<strong>Warning:</strong>The cache max age is not one of the recommended values. If this is not intentional, you should remove this custom value and save the settings, then select one of the options from the dropdown.', 'pantheon-advanced-page-cache' ) : '';

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -87,6 +87,54 @@ function add_max_age_setting_header() {
 }
 
 /**
+ * Get the callback(s) hooked to pantheon_cache_default_max_age, if one exists.
+ *
+ * @since 2.1.0
+ * @return string
+ */
+function get_pantheon_cache_filter_callback() {
+	global $wp_filter;
+	$hook = 'pantheon_cache_default_max_age';
+	$output = '';
+
+	if ( ! has_filter( $hook ) ) {
+		return $output;
+	}
+
+	$callback_functions = [];
+	if ( isset( $wp_filter[ $hook ] ) ) {
+		foreach ( $wp_filter[ $hook ]->callbacks as $priority => $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_string( $callback['function'] ) ) {
+					// Function name.
+					$callback_functions[] = $callback['function'];
+				} elseif ( is_array( $callback['function'] ) ) {
+					// Method call.
+					$class = is_object( $callback['function'][0] ) ? get_class( $callback['function'][0] ) : $callback['function'][0];
+					$method = $callback['function'][1];
+					$callback_functions[] = "$class::$method";
+				} else {
+					$callback_functions[] = 'anonymous';
+				}
+			}
+		}
+	}
+
+	$callbacks_count = count( $callback_functions );
+	if ( $callbacks_count === 1 ) {
+		return "<code>{$callback_functions[0]}</code>";
+	}
+
+	// If there are multiple callbacks, format the output.
+	foreach ( $callback_functions as $index => $callback ) {
+		$callback = $callback === 'anonymous' ? __( 'an anonymous function', 'pantheon-advanced-page-cache' ) : "<code>$callback</code>";
+		$output .= $index === $callbacks_count - 1 ? ' ' . __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
+	}
+
+	return $output;
+}
+
+/**
  * Add a description to the max-age setting field.
  *
  * @since 2.0.0

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -114,7 +114,7 @@ function get_pantheon_cache_filter_callback() {
 					$method = $callback['function'][1];
 					$callback_functions[] = "$class::$method";
 				} else {
-					$callback_functions[] = 'anonymous';
+					$callback_functions[] = __( 'an anonymous function', 'pantheon-advanced-page-cache' );
 				}
 			}
 		}

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -128,8 +128,8 @@ function get_pantheon_cache_filter_callback() {
 
 	// If there are multiple callbacks, format the output.
 	foreach ( $callback_functions as $index => $callback ) {
-		$callback = $callback === 'anonymous' ? __( 'an anonymous function', 'pantheon-advanced-page-cache' ) : "<code>$callback</code>";
-		$output .= $index === $callbacks_count - 1 ? ' ' . __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
+		$callback = stripos( $callback, 'anonymous' ) !== false ? $callback : "<code>$callback</code>";
+		$output .= $index === $callbacks_count - 1 ? __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
 	}
 
 	return $output;

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -103,7 +103,7 @@ function get_pantheon_cache_filter_callback() {
 
 	$callback_functions = [];
 	if ( isset( $wp_filter[ $hook ] ) ) {
-		foreach ( $wp_filter[ $hook ]->callbacks as $priority => $callbacks ) {
+		foreach ( $wp_filter[ $hook ]->callbacks as $callbacks ) {
 			foreach ( $callbacks as $callback ) {
 				if ( is_string( $callback['function'] ) ) {
 					// Function name.

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -129,7 +129,7 @@ function get_pantheon_cache_filter_callback() {
 	// If there are multiple callbacks, format the output.
 	foreach ( $callback_functions as $index => $callback ) {
 		$callback = stripos( $callback, 'anonymous' ) !== false ? $callback : "<code>$callback</code>";
-		$output .= $index === $callbacks_count - 1 ? __( 'and', 'pantheon-advanced-page-cache' )  . ' '. $callback : $callback . ', ';
+		$output .= $index === $callbacks_count - 1 ? __( 'and', 'pantheon-advanced-page-cache' ) . ' ' . $callback : $callback . ', ';
 	}
 
 	return $output;

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -120,9 +120,10 @@ function get_pantheon_cache_filter_callback() {
 		}
 	}
 
+	// Count the callbacks and if there's only one, return the name (if able).
 	$callbacks_count = count( $callback_functions );
 	if ( $callbacks_count === 1 ) {
-		return "<code>{$callback_functions[0]}</code>";
+		return stripos( $callback_functions[0], 'an anonymous function' ) === false ? "<code>{$callback_functions[0]}<code>" : $callback_functions[0];
 	}
 
 	// If there are multiple callbacks, format the output.

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -648,24 +648,26 @@ function max_age_updated_admin_notice() {
 	update_user_meta( $current_user_id, 'pantheon_max_age_updated_notice', true );
 }
 
+
 /**
- * Filter the nonce cache lifetime.
+ * Filter the cache lifetime for nonces.
  *
- * @param int $lifetime The lifetime of the nonce.
+ * Hooked to pantheon_cache_nonce_lifetime action. Use this to filter the cache lifetime for nonces using the action, e.g.:
+ *
+ * do_action( 'pantheon_cache_nonce_lifetime' );
  *
  * @since 2.0.0
- * @return int
+ * @return void
  */
-function filter_nonce_cache_lifetime( $lifetime ) {
+function filter_nonce_cache_lifetime() {
 	// Bail early if we're in the admin.
 	if ( is_admin() ) {
-		return $lifetime;
+		return;
 	}
 
 	// Filter the cache default max age to less than the nonce lifetime when creating nonces on the front-end. This prevents the cache from keeping the nonce around longer than it should.
-	add_filter( 'pantheon_cache_default_max_age', function () use ( $lifetime ) {
+	add_filter( 'pantheon_cache_default_max_age', function () {
+		$lifetime = apply_filters( 'nonce_life', DAY_IN_SECONDS );
 		return $lifetime - HOUR_IN_SECONDS;
 	} );
-
-	return $lifetime;
 }

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -42,7 +42,7 @@ function bootstrap() {
 	add_filter( 'pantheon_cache_max_age_field_after_html', __NAMESPACE__ . '\\add_max_age_setting_description' );
 	add_filter( 'pantheon_cache_max_age_input', __NAMESPACE__ . '\\update_default_ttl_input' );
 	add_filter( 'pantheon_cache_max_age_input_allowed_html', __NAMESPACE__ . '\\max_age_input_allowed_html' );
-	add_filter( 'nonce_life', __NAMESPACE__ . '\\filter_nonce_cache_lifetime' );
+	add_action( 'pantheon_cache_nonce_lifetime', __NAMESPACE__ . '\\filter_nonce_cache_lifetime' );
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -160,15 +160,13 @@ The cache max age setting is controlled by the [Pantheon Page Cache](https://doc
 
 When the cache max age is filtered in this way, the admin option is disabled and a notice is displayed.
 
-= Setting the Cache Max Age with a filter =
+= Updating the cache max age based on nonces =
 
-The cache max age setting is controlled by the [Pantheon Page Cache](https://docs.pantheon.io/guides/wordpress-configurations/wordpress-cache-plugin) admin page. As of 2.0.0, there are three cache age options by default — 1 week, 1 month, 1 year. Pantheon Advanced Page Cache automatically purges the cache of updated and related posts and pages, but you might want to override the cache max age value and set it programmatically. In this case, you can use the `pantheon_cache_default_max_age` filter added in [Pantheon MU plugin 1.4.0+](https://docs.pantheon.io/guides/wordpress-configurations/wordpress-cache-plugin#override-the-default-max-age). For example:
+Nonces created on the front-end, often used to secure forms and other data, have a lifetime, and if the cache max age is longer than the nonce lifetime, the nonce may expire before the cache does. To avoid this, you can use the `pantheon_cache_nonce_lifetime` action to set the `pantheon_cache_default_max_age` to less than the nonce lifetime. For example:
 
-	add_filter( 'pantheon_cache_default_max_age', function() {
-		return 10 * DAY_IN_SECONDS;
-	} );
+	do_action( 'pantheon_cache_nonce_lifetime' );
 
-When the cache max age is filtered in this way, the admin option is disabled and a notice is displayed.
+It's important to wrap your `do_action` in the appropriate conditionals to ensure that the action is only called when necessary and not filtering the cache max age in cases when it's not necessary. This might mean only running on certain pages or in certain contexts in your code.
 
 == WP-CLI Commands ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler
 Tags: pantheon, cdn, cache
 Requires at least: 6.4
-Tested up to: 6.5.3
+Tested up to: 6.6.1
 Stable tag: 2.0.1-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -3,23 +3,28 @@ Feature: Adjust the Default Max Age setting
 Background:
 	Given I log in as an admin
 
-Scenario: Set max age to 600 and auto-update to the default value
+Scenario: Auto-update to the default value if the value
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	And I fill in "pantheon-cache[default_ttl]" with "600"
-	And I press "Save Changes"
 	Then I should see "The Pantheon GCDN cache max age has been updated. The previous value was 10 minutes. The new value is 1 week."
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	Then the "pantheon-cache[default_ttl]" field should contain "604800"
-
-Scenario: Change the cache max age
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	And I fill in "pantheon-cache[default_ttl]" with "300"
-	And I press "Save Changes"
-	Then I should see "This is a very low value and may not be optimal for your site" in the ".notice" element
-	And I should see "Consider increasing the cache max age to at least 1 week" in the ".notice" element
+	And the "pantheon-cache[default_ttl]" field should contain "604800"
 
 Scenario: Change the cache max age to 1 week
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "604800"
 	And I press "Save Changes"
 	Then I should see "Settings saved."
+	And the "pantheon-cache[default_ttl]" field should contain "604800"
+
+Scenario: Change the cache max age to 1 month
+	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
+	And I fill in "pantheon-cache[default_ttl]" with "2592000"
+	And I press "Save Changes"
+	Then I should see "Settings saved."
+	And the "pantheon-cache[default_ttl]" field should contain "2592000"
+
+Scenario: Change the cache max age to 1 year
+	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
+	And I fill in "pantheon-cache[default_ttl]" with "31536000"
+	And I press "Save Changes"
+	Then I should see "Settings saved."
+	And the "pantheon-cache[default_ttl]" field should contain "31536000"

--- a/tests/behat/admin-interface.feature
+++ b/tests/behat/admin-interface.feature
@@ -3,11 +3,6 @@ Feature: Adjust the Default Max Age setting
 Background:
 	Given I log in as an admin
 
-Scenario: Auto-update to the default value if the value
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	Then I should see "The Pantheon GCDN cache max age has been updated. The previous value was 10 minutes. The new value is 1 week."
-	And the "pantheon-cache[default_ttl]" field should contain "604800"
-
 Scenario: Change the cache max age to 1 week
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "604800"

--- a/tests/behat/site-health.feature
+++ b/tests/behat/site-health.feature
@@ -3,22 +3,6 @@ Feature: Site Health tests based on Cache Max Age
 Background:
 	Given I log in as an admin
 
-Scenario: Site Health should report when Max Age is a low value
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	And I fill in "pantheon-cache[default_ttl]" with "300"
-	And I press "Save Changes"
-	And I go to "/wp-admin/site-health.php"
-	Then I should see "Pantheon GCDN Cache Max Age"
-	And I should see "The Pantheon GCDN cache max age is currently set to 5 mins. We recommend increasing to 1 week"
-
-Scenario: Site Health should report when Max age is less than the recommendation
-	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
-	And I fill in "pantheon-cache[default_ttl]" with "432000"
-	And I press "Save Changes"
-	And I go to "/wp-admin/site-health.php"
-	Then I should see "Pantheon GCDN Cache Max Age"
-	And I should see "The Pantheon GCDN cache max age is currently set to 5 days. We recommend increasing to 1 week"
-
 Scenario: Site Health check should pass when Max Age is the recommneded value
 	When I go to "/wp-admin/options-general.php?page=pantheon-cache"
 	And I fill in "pantheon-cache[default_ttl]" with "604800"

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -353,6 +353,20 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	}
 
 	/**
+	 * Filter callback for testing pantheon_cache_default_max_age.
+	 */
+	public function reset_cache_max_age() {
+		return 0;
+	}
+
+	/**
+	 * Filter callback for testing pantheon_cache_default_max_age.
+	 */
+	public function another_function() {
+		return 42;
+	}
+
+	/**
 	 * Test the update_default_ttl_input function. Check the input type if the max age has been filtered.
 	 *
 	 * @dataProvider update_default_ttl_input_provider

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -503,10 +503,20 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		}
 
 		$nonce_life = apply_filters( 'nonce_life', DAY_IN_SECONDS );
-		filter_nonce_cache_lifetime( $nonce_life );
-		$nonce_cache_lifetime = apply_filters( 'pantheon_cache_default_max_age', $nonce_life );
+		do_action( 'pantheon_cache_nonce_lifetime' );
+		$cache_max_age = apply_filters( 'pantheon_cache_default_max_age', $nonce_life );
 
-		$this->assertEquals( $expected, $nonce_cache_lifetime, sprintf( '%s test failed to assert that %s was equal to %s', $screen, humanized_max_age( $nonce_cache_lifetime ), humanized_max_age( $expected ) ) );
+		$this->assertEquals(
+			$expected,
+			$cache_max_age,
+			sprintf(
+				// 1: Screen, 2: Cache max age, 3: Expected max age.
+				'%s test failed to assert that %s was equal to %s',
+				$screen,
+				humanized_max_age( $cache_max_age ),
+				humanized_max_age( $expected )
+			)
+		);
 	}
 
 	/**

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -16,6 +16,10 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	private function get_five_minutes() {
 		$wp_version = get_bloginfo( 'version' );
+
+		// If the version contains a string like -alpha, -beta, etc., strip it.
+		$wp_version = preg_replace( '/-.*/', '', $wp_version );
+
 		// WordPress 6.7 changed the string for "5 mins" to "5 minutes".
 		$five_mins = version_compare( $wp_version, '6.7', '<' ) ? '5 mins' : '5 minutes';
 		return $five_mins;
@@ -112,6 +116,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function humanized_max_age_provider() {
 		$five_mins = $this->get_five_minutes();
+		var_dump( $five_mins );
 		return [
 			[ 300, $five_mins ], // 300 seconds is humanized to 5 mins.
 			[ 5 * DAY_IN_SECONDS, '5 days' ],

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -116,7 +116,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function humanized_max_age_provider() {
 		$five_mins = $this->get_five_minutes();
-		var_dump( $five_mins );
+
 		return [
 			[ 300, $five_mins ], // 300 seconds is humanized to 5 mins.
 			[ 5 * DAY_IN_SECONDS, '5 days' ],

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -53,7 +53,8 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		$test_results = test_cache_max_age();
 		$this->assertEquals( 'recommended', $test_results['status'] );
 		$this->assertEquals( 'red',$test_results['badge']['color'] );
-		$this->assertStringContainsString( '5 mins', $test_results['description'] );
+		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
+		$this->assertStringContainsString( $five_mins, $test_results['description'] );
 		$this->assertStringContainsString( 'We recommend increasing to 1 week', $test_results['description'] );
 	}
 
@@ -99,8 +100,9 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 * @return array
 	 */
 	public function humanized_max_age_provider() {
+		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
 		return [
-			[ 300, '5 mins' ], // 300 seconds is humanized to 5 mins.
+			[ 300, $five_mins ], // 300 seconds is humanized to 5 mins.
 			[ 5 * DAY_IN_SECONDS, '5 days' ],
 			[ WEEK_IN_SECONDS, '1 week' ],
 		];

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -328,6 +328,14 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 			add_filter( 'pantheon_cache_default_max_age', function() {
 				return 10 * DAY_IN_SECONDS;
 			} );
+		} elseif ( $max_age === 'multiple-filters-below' ) {
+			add_filter( 'pantheon_cache_default_max_age', [ $this, 'reset_cache_max_age' ] );
+			add_filter( 'pantheon_cache_default_max_age', [ $this, 'another_function' ] );
+			add_filter( 'pantheon_cache_default_max_age', function() {
+				return 3 * DAY_IN_SECONDS;
+			} );
+		} elseif ( $max_age === 'just-named-filters' ) {
+			add_filter( 'pantheon_cache_default_max_age', [ $this, 'reset_cache_max_age' ] );
 		} else {
 			update_option( 'pantheon-cache', [ 'default_ttl' => $max_age ] );
 		}
@@ -343,8 +351,10 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function add_max_age_setting_description_provider() {
 		return [
-			[ 'filter-below', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>3 days</strong> via a filter.' ],
-			[ 'filter-above', 'Your cache maximum age is currently <strong>above</strong> the recommended value. This value has been hardcoded to <strong>1 week</strong> via a filter.' ],
+			[ 'filter-below', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>3 days</strong> via a filter hooked to an anonymous function in your code.' ],
+			[ 'filter-above', 'Your cache maximum age is currently <strong>above</strong> the recommended value. This value has been hardcoded to <strong>1 week</strong> via a filter hooked to an anonymous function in your code.' ],
+			[ 'multiple-filters-below', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>3 days</strong> via a filter hooked to <code>Pantheon_Advanced_Page_Cache\Admin_Interface\Admin_Interface_Functions::reset_cache_max_age</code>, <code>Pantheon_Advanced_Page_Cache\Admin_Interface\Admin_Interface_Functions::another_function</code>, and an anonymous function in your code.' ],
+			[ 'just-named-filters', 'Your cache maximum age is currently <strong>below</strong> the recommended value. This value has been hardcoded to <strong>1 second</strong> via a filter hooked to <code>Pantheon_Advanced_Page_Cache\Admin_Interface\Admin_Interface_Functions::reset_cache_max_age<code> in your code.' ],
 			[ 600, 'Your cache maximum age is currently <strong>below</strong> the recommended value. <br /><strong>Warning:</strong>The cache max age is not one of the recommended values.' ],
 			[ WEEK_IN_SECONDS, 'Your cache maximum age is currently set to the recommended value.' ],
 			[ MONTH_IN_SECONDS, 'Your cache maximum age is currently <strong>above</strong> the recommended value.' ],

--- a/tests/phpunit/test-admin-interface.php
+++ b/tests/phpunit/test-admin-interface.php
@@ -12,6 +12,16 @@ namespace Pantheon_Advanced_Page_Cache\Admin_Interface;
  */
 class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	/**
+	 * Get the WordPress version-compatible string for "5 minutes".
+	 */
+	private function get_five_minutes() {
+		$wp_version = get_bloginfo( 'version' );
+		// WordPress 6.7 changed the string for "5 mins" to "5 minutes".
+		$five_mins = version_compare( $wp_version, '6.7', '<' ) ? '5 mins' : '5 minutes';
+		return $five_mins;
+	}
+
+	/**
 	 * Set up tests.
 	 */
 	public function setUp(): void {
@@ -46,6 +56,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 */
 	public function test_site_health_tests_300_seconds() {
 		$tests = apply_filters( 'site_status_tests', [] );
+		$five_mins = $this->get_five_minutes();
 
 		$this->assertContains( 'pantheon_edge_cache', array_keys( $tests['direct'] ) );
 
@@ -53,7 +64,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 		$test_results = test_cache_max_age();
 		$this->assertEquals( 'recommended', $test_results['status'] );
 		$this->assertEquals( 'red',$test_results['badge']['color'] );
-		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
+
 		$this->assertStringContainsString( $five_mins, $test_results['description'] );
 		$this->assertStringContainsString( 'We recommend increasing to 1 week', $test_results['description'] );
 	}
@@ -100,7 +111,7 @@ class Admin_Interface_Functions extends \Pantheon_Advanced_Page_Cache_Testcase {
 	 * @return array
 	 */
 	public function humanized_max_age_provider() {
-		$five_mins = is_plugin_active( 'gutenberg/gutenberg.php' ) ? '5 minutes' : '5 mins';
+		$five_mins = $this->get_five_minutes();
 		return [
 			[ 300, $five_mins ], // 300 seconds is humanized to 5 mins.
 			[ 5 * DAY_IN_SECONDS, '5 days' ],


### PR DESCRIPTION
Removes the `add_filter` to hook `pantheon_cache_default_max_age` to `nonce_life` minus 1 hour. This was overriding the cache age and hard-coding cache lifetimes to 23 hours.

Instead, this is replaced by a new action, `pantheon_cache_nonce_lifetime` which can be called in a `do_action` when needed.

Behat tests Blocked by https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/pull/67