### PR TITLE
Bump tested up to and automate future bumps

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,6 +9,8 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+    branches:
+      - '**'
 
 jobs:
   validate-readme-spacing:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -9,8 +9,6 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-    branches:
-      - '**'
 
 jobs:
   validate-readme-spacing:

--- a/.github/workflows/validate-plugin-version.yml
+++ b/.github/workflows/validate-plugin-version.yml
@@ -1,0 +1,20 @@
+name: Validate 'Tested up to' Version
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: write
+  pull-requests: write
+  
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Validate Plugin Version
+        uses: jazzsequence/action-validate-plugin-version@v1
+        with:
+          branch: 'release'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 6.4  
-**Tested up to:** 6.6.1  
+**Tested up to:** 6.7.1  
 **Stable tag:** 2.1.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler
 Tags: pantheon, cdn, cache
 Requires at least: 6.4
-Tested up to: 6.6.1
+Tested up to: 6.7.1
 Stable tag: 2.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
* Bumps "Tested up to"
* Automates future "Tested up to" bumps


As this project uses the asset-only action, this works with PRs to `release` instead of our normal `develop` workflow.

A few notes
* This project does not use the prepare-dev action, so "Tested up to" changes still need to be merged to `develop` (that action probably needs to be updated to handle this correctly anyway)
* I think the branch config is redundant, as `release` is the default branch on this project, but seeking clarification https://github.com/jazzsequence/action-validate-plugin-version/issues/13

https://getpantheon.atlassian.net/browse/SITE-2845