### PR TITLE
Trigger Asset Release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -368,6 +368,7 @@ Pantheon Advanced Page Cache integrates with WordPress plugins, including:
 See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/master/CONTRIBUTING.md) for information on contributing.
 
 == Changelog ==
+
 = 2.1.0 (8 August 2024) =
 * Adds any callable functions hooked to the `pantheon_cache_default_max_age` filter to the message that displays in the WordPress admin when a cache max age filter is active. [[#292](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/292)] This gives some context to troubleshoot if the filter is active somewhere in the codebase. If an anonymous function is used, it is noted in the message that displays.
 * Removes the hook to `nonce_life` and replaces it with a new action (`pantheon_cache_nonce_lifetime`, see [documentation](https://github.com/pantheon-systems/pantheon-advanced-page-cache?tab=readme-ov-file#updating-the-cache-max-age-based-on-nonces)). [[#293](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/293)] This was erroneously overriding any admin settings and setting the default cache max age for some sites to always be 23 hours (the nonce lifetime minus 1 hour). This solution requires that developers add the `do_action` when they are creating nonces on the front-end, but allows the cache settings to work as designed in all other instances.


### PR DESCRIPTION
Was attempting to release the README with #306, but the catalog-info file already on `release` (which shouldn't have been there), caused the workflow to bail. Re-trying pushing with just a readme change.

Whatever fix we need to handle this better I think belongs in the check status part of https://github.com/pantheon-systems/pantheon-advanced-page-cache/blob/release/.github/workflows/build-tag-release.yml, but for now I think just this readme change will get me where I need to go ("Tested up to" fixed on wp.org).

cc @jazzsequence to brainstorm cleaning up this workflow. I think it may be as simple as setting `IGNORE_OTHER_FILES: true` (since it only pushes the readme anyway), but not sure if that opens us up to something we don't want.

https://getpantheon.atlassian.net/browse/SITE-2845