### PR TITLE
Update `wpunit-helpers` to latest to fix SVN issue.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1276,16 +1276,16 @@
         },
         {
             "name": "pantheon-systems/wpunit-helpers",
-            "version": "v2.0.0",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/wpunit-helpers.git",
-                "reference": "8f77f209060fbb9178952d0265f53af0ed2517df"
+                "reference": "8e767a2d59abc16b4fc5bedc12e0adbb87554044"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/wpunit-helpers/zipball/8f77f209060fbb9178952d0265f53af0ed2517df",
-                "reference": "8f77f209060fbb9178952d0265f53af0ed2517df",
+                "url": "https://api.github.com/repos/pantheon-systems/wpunit-helpers/zipball/8e767a2d59abc16b4fc5bedc12e0adbb87554044",
+                "reference": "8e767a2d59abc16b4fc5bedc12e0adbb87554044",
                 "shasum": ""
             },
             "require": {
@@ -1316,9 +1316,9 @@
             "description": "Unified scripts for installing and running automated WP Unit Tests.",
             "support": {
                 "issues": "https://github.com/pantheon-systems/wpunit-helpers/issues",
-                "source": "https://github.com/pantheon-systems/wpunit-helpers/tree/v2.0.0"
+                "source": "https://github.com/pantheon-systems/wpunit-helpers/tree/v2.0.2"
             },
-            "time": "2024-02-13T21:19:22+00:00"
+            "time": "2025-01-06T18:07:41+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5768,7 +5768,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
SVN is installed [on Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) but not [24.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md).

Broke plugin deploy for #308 so we get to keep playing this game.

Supercedes #309 