### PR TITLE
change branch to develop

### DIFF
--- a/.github/workflows/validate-plugin-version.yml
+++ b/.github/workflows/validate-plugin-version.yml
@@ -6,7 +6,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -17,4 +17,4 @@ jobs:
       - name: Validate Plugin Version
         uses: jazzsequence/action-validate-plugin-version@v1
         with:
-          branch: 'release'
+          branch: 'develop'


### PR DESCRIPTION
setting branch to `release` means the PR will be made against the release branch and (potentially) trigger a release if merged.

This should be adjusted to the develop branch so we don't accidentally push releases we don't want.