### PR TITLE
[BUGS-8592] Purge paths in addition to keys on publish

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           type: 'plugin'
   test:
-    needs: lint
     name: Test
     runs-on: ubuntu-latest
     services:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin/install-wp-tests.sh
 bin/install-local-tests.sh
 bin/phpunit-test.sh
 .*.cache
+
+.envrc

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Lastly, the `pantheon_wp_rest_api_surrogate_keys` filter lets you filter surroga
 
 ### Additional purging by path
 
-When a post is published for the first time, the permalink's path is also purged above and beyond the keys. This can be further filtered with the `pantheon_clear_post_path` filter.
+When a post is published for the first time, the permalink's path is also purged even if it has no matching keys. This can be further filtered with the `pantheon_clear_post_path` filter.
 
 ```php
 add_action('pantheon_clear_post_path', function($paths) {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 6.4  
-**Tested up to:** 6.6.1  
+**Tested up to:** 6.7.2  
 **Stable tag:** 2.1.1-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ Because Pantheon Advanced Page Cache already handles WordPress post purge events
 
 Lastly, the `pantheon_wp_rest_api_surrogate_keys` filter lets you filter surrogate keys present in a REST API response.
 
+### Additional purging by path
+
+When a post is published for the first time, the permalink's path is also purged above and beyond the keys. This can be further filtered with the `pantheon_clear_post_path` filter.
+
+```php
+add_action('pantheon_clear_post_path', function($paths) {
+    // Add or remove paths from $paths
+    return $paths
+}, 10, 3);
+```
+
 Need a bit more power? In addition to `pantheon_wp_clear_edge_keys()`, there are two additional helper functions you can use:
 
 * `pantheon_wp_clear_edge_paths( $paths = array() )` - Purge cache for one or more paths.
@@ -404,6 +415,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 ## Changelog ##
 
 ### 2.1.1-dev ###
+* Fixes 404 pages remaining cached after a post has been published ([#315](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/315))
 
 ### 2.1.0 (8 August 2024) ###
 * Adds any callable functions hooked to the `pantheon_cache_default_max_age` filter to the message that displays in the WordPress admin when a cache max age filter is active. [[#292](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/292)] This gives some context to troubleshoot if the filter is active somewhere in the codebase. If an anonymous function is used, it is noted in the message that displays.

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -36,6 +36,45 @@ class Purger {
 			return;
 		}
 		self::purge_post_with_related( $post );
+        error_log( sprintf(
+            'Post ID %d: ran purge_post_with_related.',
+            $post->ID
+        ) );
+		if ( 'publish' === $old_status ) {
+			return;
+		}
+		# Targets 404 pages that could be cached with no surrogate keys (i.e.
+		# a drafted post going live after the 404 has been cached).
+		self::clear_post_path( $post );
+		error_log( sprintf(
+            'Post ID %d: ran clear_post_path.',
+            $post->ID
+        ) );
+	}
+
+
+	/**
+ 	 * Purge the cache for a given post's path
+	 *
+	 * @param string  $new_status New status for the post.
+	 * @param string  $old_status Old status for the post.
+	 * @param WP_Post $post Post object.
+	 */
+	public static function clear_post_path($post) {
+	    if ($post->post_status == 'publish') {
+	        $post_path = get_permalink($post->ID);
+	        $parsed_url = parse_url($post_path);
+
+	        // Check if pantheon_clear_edge_paths is defined
+	        if (function_exists('pantheon_clear_edge_paths')) {
+	            pantheon_clear_edge_paths([$parsed_url['path']]);
+	            error_log( sprintf(
+		            'Post ID %d: cleared edge path "%s".',
+		            $post->ID, $parsed_url['path']
+		        ) );
+	        }
+
+	    }
 	}
 
 	/**

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -55,7 +55,13 @@ class Purger {
 		$parsed_url = parse_url( $post_path );
 		$path = $parsed_url['path'];
 		$paths = [ trailingslashit( $path ), untrailingslashit( $path ) ];
-	
+		
+		/**
+		 * Paths possibly without surrogate keys purges 
+		 *
+		 * @param array $paths    paths to clear.
+		 */
+		$paths = apply_filters( 'pantheon_clear_post_path', $paths );
 		pantheon_wp_clear_edge_paths( $paths );
 	}
 

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -36,28 +36,18 @@ class Purger {
 			return;
 		}
 		self::purge_post_with_related( $post );
-		error_log( sprintf(
-			'Post ID %d: ran purge_post_with_related.',
-			$post->ID
-		) );
 		if ( 'publish' === $old_status ) {
 			return;
 		}
 		// Targets 404 pages that could be cached with no surrogate keys (i.e.
 		// a drafted post going live after the 404 has been cached).
 		self::clear_post_path( $post );
-		error_log( sprintf(
-			'Post ID %d: ran clear_post_path.',
-			$post->ID
-		) );
 	}
 
 
 	/**
 	 * Purge the cache for a given post's path
 	 *
-	 * @param string  $new_status New status for the post.
-	 * @param string  $old_status Old status for the post.
 	 * @param WP_Post $post Post object.
 	 */
 	public static function clear_post_path( $post ) {
@@ -67,10 +57,6 @@ class Purger {
 		$paths = [ trailingslashit( $path ), untrailingslashit( $path ) ];
 	
 		pantheon_wp_clear_edge_paths( $paths );
-		error_log( sprintf(
-			'Post ID %d: cleared edge path "%s".',
-			$post->ID, $parsed_url['path']
-		) );
 	}
 
 	/**

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -36,10 +36,10 @@ class Purger {
 			return;
 		}
 		self::purge_post_with_related( $post );
-        error_log( sprintf(
-            'Post ID %d: ran purge_post_with_related.',
-            $post->ID
-        ) );
+		error_log( sprintf(
+			'Post ID %d: ran purge_post_with_related.',
+			$post->ID
+		) );
 		if ( 'publish' === $old_status ) {
 			return;
 		}
@@ -47,34 +47,30 @@ class Purger {
 		# a drafted post going live after the 404 has been cached).
 		self::clear_post_path( $post );
 		error_log( sprintf(
-            'Post ID %d: ran clear_post_path.',
-            $post->ID
-        ) );
+			'Post ID %d: ran clear_post_path.',
+			$post->ID
+		) );
 	}
 
 
 	/**
- 	 * Purge the cache for a given post's path
+	 * Purge the cache for a given post's path
 	 *
 	 * @param string  $new_status New status for the post.
 	 * @param string  $old_status Old status for the post.
 	 * @param WP_Post $post Post object.
 	 */
 	public static function clear_post_path($post) {
-	    if ($post->post_status == 'publish') {
-	        $post_path = get_permalink($post->ID);
-	        $parsed_url = parse_url($post_path);
-
-	        // Check if pantheon_clear_edge_paths is defined
-	        if (function_exists('pantheon_clear_edge_paths')) {
-	            pantheon_clear_edge_paths([$parsed_url['path']]);
-	            error_log( sprintf(
-		            'Post ID %d: cleared edge path "%s".',
-		            $post->ID, $parsed_url['path']
-		        ) );
-	        }
-
-	    }
+		$post_path = get_permalink($post->ID);
+		$parsed_url = parse_url($post_path);
+		$path = $parsed_url['path'];
+		$paths = [trailingslashit( $path ), untrailingslashit( $path )];
+	
+		pantheon_wp_clear_edge_paths($paths);
+		error_log( sprintf(
+			'Post ID %d: cleared edge path "%s".',
+			$post->ID, $parsed_url['path']
+		) );
 	}
 
 	/**

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -43,8 +43,8 @@ class Purger {
 		if ( 'publish' === $old_status ) {
 			return;
 		}
-		# Targets 404 pages that could be cached with no surrogate keys (i.e.
-		# a drafted post going live after the 404 has been cached).
+		// Targets 404 pages that could be cached with no surrogate keys (i.e.
+		// a drafted post going live after the 404 has been cached).
 		self::clear_post_path( $post );
 		error_log( sprintf(
 			'Post ID %d: ran clear_post_path.',
@@ -60,13 +60,13 @@ class Purger {
 	 * @param string  $old_status Old status for the post.
 	 * @param WP_Post $post Post object.
 	 */
-	public static function clear_post_path($post) {
-		$post_path = get_permalink($post->ID);
-		$parsed_url = parse_url($post_path);
+	public static function clear_post_path( $post ) {
+		$post_path = get_permalink( $post->ID );
+		$parsed_url = parse_url( $post_path );
 		$path = $parsed_url['path'];
-		$paths = [trailingslashit( $path ), untrailingslashit( $path )];
+		$paths = [ trailingslashit( $path ), untrailingslashit( $path ) ];
 	
-		pantheon_wp_clear_edge_paths($paths);
+		pantheon_wp_clear_edge_paths( $paths );
 		error_log( sprintf(
 			'Post ID %d: cleared edge path "%s".',
 			$post->ID, $parsed_url['path']

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,7 @@ Lastly, the `pantheon_wp_rest_api_surrogate_keys` filter lets you filter surroga
 
 = Additional purging by path =
 
-When a post is published for the first time, the permalink's path is also purged above and beyond the keys. This can be further filtered with the `pantheon_clear_post_path` filter.
+When a post is published for the first time, the permalink's path is also purged even if it has no matching keys. This can be further filtered with the `pantheon_clear_post_path` filter.
 
         add_action('pantheon_clear_post_path', function($paths) {
             // Add or remove paths from $paths

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler
 Tags: pantheon, cdn, cache
 Requires at least: 6.4
-Tested up to: 6.6.1
+Tested up to: 6.7.2
 Stable tag: 2.1.1-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,15 @@ Because Pantheon Advanced Page Cache already handles WordPress post purge events
 
 Lastly, the `pantheon_wp_rest_api_surrogate_keys` filter lets you filter surrogate keys present in a REST API response.
 
+= Additional purging by path =
+
+When a post is published for the first time, the permalink's path is also purged above and beyond the keys. This can be further filtered with the `pantheon_clear_post_path` filter.
+
+        add_action('pantheon_clear_post_path', function($paths) {
+            // Add or remove paths from $paths
+            return $paths
+        }, 10, 3);
+
 Need a bit more power? In addition to `pantheon_wp_clear_edge_keys()`, there are two additional helper functions you can use:
 
 * `pantheon_wp_clear_edge_paths( $paths = array() )` - Purge cache for one or more paths.
@@ -368,6 +377,9 @@ Pantheon Advanced Page Cache integrates with WordPress plugins, including:
 See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/master/CONTRIBUTING.md) for information on contributing.
 
 == Changelog ==
+
+= 2.11.1-dev =
+* Fixes 404 pages remaining cached after a post has been published ([#315](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/315))
 
 = 2.1.0 (8 August 2024) =
 * Adds any callable functions hooked to the `pantheon_cache_default_max_age` filter to the message that displays in the WordPress admin when a cache max age filter is active. [[#292](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/292)] This gives some context to troubleshoot if the filter is active somewhere in the codebase. If an anonymous function is used, it is noted in the message that displays.

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -1877,9 +1877,9 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 			'post_date_gmt'=> get_gmt_from_date($future_date),
 		), true);
 
-		$this->assertFalse(is_wp_error($result)); # Didn't throw an error updating
+		$this->assertFalse(is_wp_error($result)); // Didn't throw an error updating
 
-		# Intercept the filter added to clear_post_path
+		// Intercept the filter added to clear_post_path
 		add_action('pantheon_clear_post_path', function($paths) use (&$clear_callback_called, &$clear_callback_args) {
 			$clear_callback_args["paths"] = $paths;
 			$clear_callback_called = true;
@@ -1891,5 +1891,10 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 	
 		$expected = array( "/2025/02/25/fourth-post", "/2025/02/25/fourth-post/" );
 		$this->assertEqualsCanonicalizing($expected, $clear_callback_args["paths"], "expected paths were not cleared");
+
+		// Paths aren't cleared again if the post was already published
+		$clear_callback_called = false;
+		wp_publish_post($this->post_id4);
+		$this->assertFalse($clear_callback_called);
 	}
 }

--- a/tests/phpunit/test-purger.php
+++ b/tests/phpunit/test-purger.php
@@ -1866,4 +1866,30 @@ class Test_Purger extends Pantheon_Advanced_Page_Cache_Testcase {
 		// Clean up after the test.
 		$this->after_filter_ignore_posts();
 	}
+
+	public function test_future_post_clears_on_published() {
+		$future_date = date('Y-m-d H:i:s', strtotime('+1 day')); // Schedules for 1 day later
+
+		$result = wp_update_post(array(
+			'ID'           => $this->post_id4,
+			'post_status'  => 'future',
+			'post_date'    => $future_date,
+			'post_date_gmt'=> get_gmt_from_date($future_date),
+		), true);
+
+		$this->assertFalse(is_wp_error($result)); # Didn't throw an error updating
+
+		# Intercept the filter added to clear_post_path
+		add_action('pantheon_clear_post_path', function($paths) use (&$clear_callback_called, &$clear_callback_args) {
+			$clear_callback_args["paths"] = $paths;
+			$clear_callback_called = true;
+        }, 10, 3);
+
+        wp_publish_post($this->post_id4);
+		
+        $this->assertTrue($clear_callback_called, 'The pantheon_clear_post_path action was not fired.');
+	
+		$expected = array( "/2025/02/25/fourth-post", "/2025/02/25/fourth-post/" );
+		$this->assertEqualsCanonicalizing($expected, $clear_callback_args["paths"], "expected paths were not cleared");
+	}
 }


### PR DESCRIPTION
Clears a cached 404 page when a scheduled post is published for the first time. In certain cases, 404 pages could be cached without a surrogate key getting included when `purge_post_with_related` fires on transition_post_status.

- [x] CI tests
- [x] Cleanup logging
- [x] changelog