### PR TITLE
Change the Site Health label to Pantheon

### DIFF
--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -497,7 +497,7 @@ function test_cache_max_age() {
 			'label' => __( 'Pantheon GCDN Cache Max Age', 'pantheon-advanced-page-cache' ),
 			'status' => 'recommended',
 			'badge' => [
-				'label' => __( 'Performance', 'pantheon-advanced-page-cache' ),
+				'label' => __( 'Pantheon', 'pantheon-advanced-page-cache' ),
 				'color' => $recommend_color,
 			],
 			'description' => sprintf(
@@ -522,7 +522,7 @@ function test_cache_max_age() {
 		),
 		'status' => 'good',
 		'badge' => [
-			'label' => __( 'Performance', 'pantheon-advanced-page-cache' ),
+			'label' => __( 'Pantheon', 'pantheon-advanced-page-cache' ),
 			'color' => 'blue',
 		],
 		'description' => sprintf(


### PR DESCRIPTION
This commit changes the label for the Site Health test to Pantheon, so it's clear where the test is coming from. It's often difficult to distinguish what tests are coming from WordPress core and what tests are coming from plugins. We can disambiguate that by being clear about tests that we are specifically adding to the Site Health page.