### PR TITLE
[SITE-5390] Explicitly purge REST API term endpoints when draft posts are updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 6.4  
-**Tested up to:** 6.9 
+**Tested up to:** 6.9  
 **Requires PHP:** 7.4  
 **Stable tag:** 2.1.2-dev  
 **License:** GPLv2 or later  

--- a/README.md
+++ b/README.md
@@ -415,7 +415,8 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 
 ## Changelog ##
 
-### 2.1.2-dev
+### 2.1.2-dev ###
+* Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357)) 
 
 ### 2.1.1 (25 February 2025) ###
 * Fixes 404 pages remaining cached after a post has been published ([#315](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/315))

--- a/README.md
+++ b/README.md
@@ -416,6 +416,8 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 ## Changelog ##
 
 ### 2.1.2-dev ###
+* Confirmed PHP 8.4 compatibility [[#333](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/333)]
+* Confirmed WordPress 6.9 compatibility [[#355](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/355)]
 * Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357)) 
 
 ### 2.1.1 (25 February 2025) ###

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 6.4  
-**Tested up to:** 6.8.2  
+**Tested up to:** 6.9 
 **Requires PHP:** 7.4  
 **Stable tag:** 2.1.2-dev  
 **License:** GPLv2 or later  

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -46,12 +46,13 @@ class Purger {
 			}
 		}
 
-		if ( $has_terms ) {
-			$keys[] = 'term-huge';
-			$keys[] = 'rest-term-huge';
-			$keys = pantheon_wp_prefix_surrogate_keys_with_blog_id( $keys );
-			pantheon_wp_clear_edge_keys( $keys );
+		if ( ! $has_terms ) {
+			return;
 		}
+		$keys[] = 'term-huge';
+		$keys[] = 'rest-term-huge';
+		$keys = pantheon_wp_prefix_surrogate_keys_with_blog_id( $keys );
+		pantheon_wp_clear_edge_keys( $keys );
 	}
 
 	/**

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -326,6 +326,8 @@ class Purger {
 			'404',
 			'feed',
 			'post-huge',
+			'rest-post-' . $post->ID,
+			'rest-post-huge',
 		];
 
 		if ( post_type_supports( $post->post_type, 'author' ) ) {
@@ -348,8 +350,10 @@ class Purger {
 			if ( $terms ) {
 				foreach ( $terms as $term ) {
 					$keys[] = 'term-' . $term->term_id;
+					$keys[] = 'rest-term-' . $term->term_id;
 				}
 				$keys[] = 'term-huge';
+				$keys[] = 'rest-term-huge';
 			}
 		}
 

--- a/inc/class-purger.php
+++ b/inc/class-purger.php
@@ -18,10 +18,40 @@ class Purger {
 	 * @param object  $post    The post object.
 	 */
 	public static function action_wp_insert_post( $post_id, $post ) {
-		if ( 'publish' !== $post->post_status ) {
+		if ( 'publish' === $post->post_status ) {
+			self::purge_post_with_related( $post );
 			return;
 		}
-		self::purge_post_with_related( $post );
+
+		// For non-published posts, still purge term keys if the post has taxonomies.
+		$taxonomies = wp_list_filter(
+			get_object_taxonomies( $post->post_type, 'objects' ),
+			[ 'public' => true ]
+		);
+
+		if ( empty( $taxonomies ) ) {
+			return;
+		}
+
+		$keys = [];
+		$has_terms = false;
+		foreach ( $taxonomies as $taxonomy ) {
+			$terms = get_the_terms( $post, $taxonomy->name );
+			if ( $terms ) {
+				$has_terms = true;
+				foreach ( $terms as $term ) {
+					$keys[] = 'term-' . $term->term_id;
+					$keys[] = 'rest-term-' . $term->term_id;
+				}
+			}
+		}
+
+		if ( $has_terms ) {
+			$keys[] = 'term-huge';
+			$keys[] = 'rest-term-huge';
+			$keys = pantheon_wp_prefix_surrogate_keys_with_blog_id( $keys );
+			pantheon_wp_clear_edge_keys( $keys );
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -380,6 +380,8 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/mast
 == Changelog ==
 
 = 2.1.2-dev =
+* Confirmed PHP 8.4 compatibility [[#333](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/333)]
+* Confirmed WordPress 6.9 compatibility [[#355](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/355)]
 * Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357)) 
 
 = 2.1.1 (25 February 2025) =

--- a/readme.txt
+++ b/readme.txt
@@ -380,7 +380,7 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/mast
 == Changelog ==
 
 = 2.1.2-dev =
-* Confirmed PHP 8.4 compatibility [[#333](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/333)]
+* Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357)) 
 
 = 2.1.1 (25 February 2025) =
 * Fixes 404 pages remaining cached after a post has been published ([#315](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/315))

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler
 Tags: pantheon, cdn, cache
 Requires at least: 6.4
-Tested up to: 6.8.2
+Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 2.1.2-dev
 License: GPLv2 or later


### PR DESCRIPTION
WordPress Core introduced two optimizations (Tickets #63562 and #42522) on June 29 and July 25, 2025, to avoid unnecessary recalculations of term counts for non-public statuses like 'draft'. Now, it's skipping the call to clean_term_cache() when a draft post with terms is saved. 

Tests started failing when updating draft posts with assigned categories or tags. The plugin was not purging term-related cache keys (`rest-term-*`) when non-published posts were modified.

The following errors:
  - test_update_post - missing rest-term-* keys
  - test_update_post_draft - missing rest-term-* keys
  - test_update_product - missing rest-term-* keys

See issue: https://github.com/pantheon-systems/pantheon-advanced-page-cache/issues/335

The plugin previously relied on WordPress Core to call `clean_term_cache()` when terms were updated, triggering the plugin's `action_clean_term_cache()` hook. Now we are doing it explicitly for both published and draft posts.

✅ Adding rest-term-* keys to purge_post_with_related() for published posts. 


❓ Since tests were added in 2023, do we want to keep purging keys for draft posts or should we follow WordPress Core optimisation and also optimize our purging logic. 