### PR TITLE
Fix HTML tag closing in admin interface and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Pantheon Advanced Page Cache #
 
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)  
-**Tags:** pantheon, cdn, cache  
-**Requires at least:** 6.4  
-**Tested up to:** 6.9  
-**Requires PHP:** 7.4  
-**Stable tag:** 2.1.3-dev  
-**License:** GPLv2 or later  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler)
+**Tags:** pantheon, cdn, cache
+**Requires at least:** 6.4
+**Tested up to:** 6.9
+**Requires PHP:** 7.4
+**Stable tag:** 2.1.3
+**License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Automatically clear related pages from Pantheon's Edge when you update content. High TTL. Fresh content. Visitors never wait.
@@ -415,12 +415,13 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/pantheon-advanced-page
 
 ## Changelog ##
 
-### 2.1.3-dev ###
+### 2.1.3 (April 24, 2026) ###
+* Fixed a markup issue that was causing empty nested &lt;code> blocks in the admin interface.
 
 ### 2.1.2 (December 16, 2025) ###
 * Confirmed PHP 8.4 compatibility [[#333](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/333)]
 * Confirmed WordPress 6.9 compatibility [[#355](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/355)]
-* Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([#357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357)) 
+* Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([#357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357))
 
 ### 2.1.1 (25 February 2025) ###
 * Fixes 404 pages remaining cached after a post has been published ([#315](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/315))

--- a/inc/admin-interface.php
+++ b/inc/admin-interface.php
@@ -123,7 +123,7 @@ function get_pantheon_cache_filter_callback() {
 	// Count the callbacks and if there's only one, return the name (if able).
 	$callbacks_count = count( $callback_functions );
 	if ( $callbacks_count === 1 ) {
-		return stripos( $callback_functions[0], 'an anonymous function' ) === false ? "<code>{$callback_functions[0]}<code>" : $callback_functions[0];
+		return stripos( $callback_functions[0], 'an anonymous function' ) === false ? "<code>{$callback_functions[0]}</code>" : $callback_functions[0];
 	}
 
 	// If there are multiple callbacks, format the output.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pantheon-advanced-page-cache",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Pantheon",
   "license": "GPL-2.0-only",
   "homepage": "https://github.com/pantheon-systems/pantheon-advanced-page-cache",

--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -7,7 +7,7 @@
  * Author URI: https://pantheon.io
  * Text Domain: pantheon-advanced-page-cache
  * Domain Path: /languages
- * Version: 2.1.3-dev
+ * Version: 2.1.3
  * Requires at least: 6.4
  * Tested up to: 6.9
  *

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: pantheon, cdn, cache
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.1.3-dev
+Stable tag: 2.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -379,12 +379,13 @@ See [CONTRIBUTING.md](https://github.com/pantheon-systems/wp-saml-auth/blob/mast
 
 == Changelog ==
 
-= 2.1.3-dev =
+= 2.1.3 (April 24, 2026) =
+* Fixed a markup issue that was causing empty nested &lt;code> blocks in the admin interface.
 
 = 2.1.2 (December 16, 2025) =
 * Confirmed PHP 8.4 compatibility [[#333](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/333)]
 * Confirmed WordPress 6.9 compatibility [[#355](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/355)]
-* Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([#357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357)) 
+* Adding rest-term-* keys to purge_post_with_related() for published and draft posts. ([#357](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/357))
 
 = 2.1.1 (25 February 2025) =
 * Fixes 404 pages remaining cached after a post has been published ([#315](https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/315))


### PR DESCRIPTION
A <code></code> block was being improperly code (closing tag was missing the slash), causing nested but ultimately empty <code> blocks in the admin interface.