### PR TITLE
[SITE-5429] Verify PAPC compatibility with Cloudflare GCDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber), [kporras07](https://profiles.wordpress.org/kporras07), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence/), [ryanshoover](https://profiles.wordpress.org/ryanshoover/), [rwagner00](https://profiles.wordpress.org/rwagner00/), [pwtyler](https://profiles.wordpress.org/pwtyler), [metasim](https://profiles.wordpress.org/metasim/)  
 **Tags:** pantheon, cdn, cache  
 **Requires at least:** 6.4  
-**Tested up to:** 7.0  
+**Tested up to:** 7.0.2  
 **Requires PHP:** 7.4  
 **Stable tag:** 2.1.3-dev  
 **License:** GPLv2 or later  

--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * Version: 2.1.3-dev
  * Requires at least: 6.4
- * Tested up to: 7.0
+ * Tested up to: 7.0.2
  *
  * @package         Pantheon_Advanced_Page_Cache
  */

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler, metasim
 Tags: pantheon, cdn, cache
 Requires at least: 6.4
-Tested up to: 7.0
+Tested up to: 7.0.2
 Requires PHP: 7.4
 Stable tag: 2.1.3-dev
 License: GPLv2 or later


### PR DESCRIPTION
## Summary

[SITE-5429](https://getpantheon.atlassian.net/browse/SITE-5429): Verify PAPC works correctly on Cloudflare-based GCDN. The fixture site has been migrated to Cloudflare. This PR triggers Behat CI against the migrated site.

Manual testing on a separate site (wp-test-august) confirmed caching, full purge, and surrogate-key-specific purge all work on Cloudflare. This Behat run validates the same behavior through the existing test suite.

Also bumps "Tested up to" to WordPress 7.0.2.

## Test plan

- [ ] Behat CI passes against the Cloudflare-migrated fixture site

[SITE-5429]: https://getpantheon.atlassian.net/browse/SITE-5429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ