### PR TITLE
[SITE-5429] Verify PAPC compatibility with Cloudflare GCDN

### DIFF
--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -13,6 +13,8 @@
  * Tested up to: 7.0
  *
  * @package         Pantheon_Advanced_Page_Cache
+ *
+ * Verified compatible with Cloudflare-based GCDN (SITE-5429).
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary

[SITE-5429](https://getpantheon.atlassian.net/browse/SITE-5429): Verify PAPC works correctly on Cloudflare-based GCDN. The fixture site has been migrated to Cloudflare. This PR triggers Behat CI against the migrated site.

Manual testing on a separate site (wp-test-august) confirmed caching, full purge, and surrogate-key-specific purge all work on Cloudflare. This Behat run validates the same behavior through the existing test suite.

## Test plan

- [ ] Behat CI passes against the Cloudflare-migrated fixture site

[SITE-5429]: https://getpantheon.atlassian.net/browse/SITE-5429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ