### PR TITLE
chore: group dependabot minor/patch updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     day: tuesday
   target-branch: "main"
   open-pull-requests-limit: 99
+  groups:
+    composer-minor-patch:
+      update-types:
+      - minor
+      - patch
   ignore:
   - dependency-name: phpunit/phpunit
     versions:
@@ -25,3 +30,8 @@ updates:
     day: tuesday
   target-branch: "main"
   open-pull-requests-limit: 99
+  groups:
+    npm-minor-patch:
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
Adds `groups:` blocks to both dependabot ecosystem entries in `.github/dependabot.yml`, mirroring the convention already used in pantheon-hud's dependabot.yml.

- composer: minor and patch updates are now grouped into a single `composer-minor-patch` PR
- npm: minor and patch updates are now grouped into a single `npm-minor-patch` PR
- Major version bumps remain ungrouped and continue to open as individual PRs

No other keys (schedule, timezone, day, target-branch, open-pull-requests-limit, ignore) were changed.