### PR TITLE
SITE-5791: pin actions to Node 24 release SHAs

### DIFF
--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build, Tag & Release
-        uses: pantheon-systems/plugin-release-actions/build-tag-release@a3839d25efa9d0d4270c088702c2072a2e49edde # main
+        uses: pantheon-systems/plugin-release-actions/build-tag-release@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:
           gh_token: ${{ github.token }}
           readme_md: README.md

--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -15,7 +15,7 @@ jobs:
     # Additional safety check: only run on production branches
     if: github.ref == 'refs/heads/release'
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build, Tag & Release
         uses: pantheon-systems/plugin-release-actions/build-tag-release@a3839d25efa9d0d4270c088702c2072a2e49edde # main
         with:

--- a/.github/workflows/composer-npm-diff.yml
+++ b/.github/workflows/composer-npm-diff.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Generate composer diff
         id: composer_diff
         uses: IonBazan/composer-diff-action@3140157575f6a67799cc80248ae35f5fb303ab15 # v1.2.0
-      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         with:
           header: composer-diff

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-    - uses: pantheon-systems/phpcompatibility-action@bd72eb001d4fb9817c9d6e1a157a71e287f3ff80 # dev
+    - uses: pantheon-systems/phpcompatibility-action@6bcfb79e78f644a471e856a1e92e14148a8e4017 # v1.1.4
       with:
         paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/inc/*.php
         test-versions: 8.0-

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,22 +21,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pantheon-systems/validate-readme-spacing@229ea162621009cf8e09bf2beba405017150130e # v1.0.5
   lint:
     name: PHPCS Linting
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Cache dependencies
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/vendor
         key: test-lint-dependencies-{{ checksum "composer.json" }}
         restore-keys: test-lint-dependencies-{{ checksum "composer.json" }}
     - name: Setup PHP
-      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: 8.3
     - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - uses: pantheon-systems/phpcompatibility-action@bd72eb001d4fb9817c9d6e1a157a71e287f3ff80 # dev
       with:
         paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/inc/*.php
@@ -63,16 +63,16 @@ jobs:
       matrix:
         php_version: [7.4, 8.3, 8.4, 8.5]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup PHP
-        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php_version }}
           extensions: mysqli, zip, imagick
       - name: Start MySQL Service
         run: sudo systemctl start mysql
       - name: Cache dependencies
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/vendor
           key: test-dependencies-{{ checksum "composer.json" }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
     name: Draft Release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create Draft Release PR
         uses: pantheon-systems/plugin-release-actions/release-pr@a3839d25efa9d0d4270c088702c2072a2e49edde # main
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create Draft Release PR
-        uses: pantheon-systems/plugin-release-actions/release-pr@a3839d25efa9d0d4270c088702c2072a2e49edde # main
+        uses: pantheon-systems/plugin-release-actions/release-pr@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:
           gh_token: ${{ github.token }}
           readme_md: README.md

--- a/.github/workflows/validate-actions-workflows.yml
+++ b/.github/workflows/validate-actions-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     name: Validate GitHub Actions workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install action-validator with NPM
         run: |
           npm install -g @action-validator/core @action-validator/cli --save-dev

--- a/.github/workflows/validate-plugin-version.yml
+++ b/.github/workflows/validate-plugin-version.yml
@@ -11,7 +11,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Validate Plugin Version

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ ! github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
       env:

--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
     - name: Setup PHP 8.4
-      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: "8.4"
         extensions: mysqli


### PR DESCRIPTION
GitHub removes Node.js 20 from the runners on 16 September 2026.

This pins every affected action reference in this repo to the commit SHA of a Node 24 release, with the version as a trailing comment. That covers both halves of SITE-5791 in one edit: the SHA pin removes the risk of a tag being repointed at a different commit, and the release bump clears the Node 20 removal.

Pinning `@v4` would not have been enough: v4 of `actions/checkout` and `actions/cache` runs on Node 20 itself, so each reference needed both a SHA and a version bump.

| File | Was | Now | Old runtime |
|---|---|---|---|
| `.github/workflows/build-tag-release.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/composer-npm-diff.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/composer-npm-diff.yml` | `marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405` | `marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5` | node20 |
| `.github/workflows/lint-test.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/lint-test.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/lint-test.yml` | `actions/cache@6f8efc29b200d32929f49075959781ed54ec270c` | `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0` | node16 |
| `.github/workflows/lint-test.yml` | `shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node20 |
| `.github/workflows/lint-test.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/lint-test.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/lint-test.yml` | `shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node20 |
| `.github/workflows/lint-test.yml` | `actions/cache@6f8efc29b200d32929f49075959781ed54ec270c` | `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0` | node16 |
| `.github/workflows/release-pr.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/validate-actions-workflows.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/validate-plugin-version.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/wordpress-plugin-deploy.yml` | `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` | `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` | node20 |
| `.github/workflows/wporg-validator.yml` | `shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1` | `shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2` | node20 |

Part of SITE-5791, under the CI standardization epic SITE-5778.
