### PR TITLE
Fix the nightly WordPress test failure and bump Tested up to 7.1

### DIFF
--- a/pantheon-advanced-page-cache.php
+++ b/pantheon-advanced-page-cache.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  * Version: 2.1.3-dev
  * Requires at least: 6.4
- * Tested up to: 7.0
+ * Tested up to: 7.1
  *
  * @package         Pantheon_Advanced_Page_Cache
  */

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, kporras07, jspellman, jazzs3quence, ryanshoover, rwagner00, pwtyler, metasim
 Tags: pantheon, cdn, cache
 Requires at least: 6.4
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 2.1.3-dev
 License: GPLv2 or later

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -509,8 +509,18 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 			$this->markTestSkipped( 'Test only applicable on single site.' );
 		}
 		wp_set_current_user( $this->admin_id1 );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
-		$this->server->dispatch( $request );
+		$request        = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response       = $this->server->dispatch( $request );
+		$expected_count = 15;
+		if ( version_compare( $GLOBALS['wp_version'], '7.2-alpha', '>=' ) ) {
+			$expected_count = 21;
+		} elseif ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
+			$expected_count = 20;
+		} elseif ( version_compare( $GLOBALS['wp_version'], '5.9-alpha', '>=' ) ) {
+			$expected_count = 17;
+		} elseif ( version_compare( $GLOBALS['wp_version'], '5.8', '>=' ) ) {
+			$expected_count = 16;
+		}
 		if ( ! is_multisite() ) {
 			$expected_values = [
 				'rest-setting-date_format',
@@ -600,6 +610,7 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 				[ 'blog-1-rest-setting-site_logo' ]
 			);
 		}
+		$this->assertCount( $expected_count, $response->get_data() );
 		$this->assertArrayValues(
 			$expected_values,
 			Emitter::get_rest_api_surrogate_keys()

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -512,7 +512,9 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 		$request        = new WP_REST_Request( 'GET', '/wp/v2/settings' );
 		$response       = $this->server->dispatch( $request );
 		$expected_count = 15;
-		if ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
+		if ( version_compare( $GLOBALS['wp_version'], '7.2-alpha', '>=' ) ) {
+			$expected_count = 21;
+		} elseif ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
 			$expected_count = 20;
 		} elseif ( version_compare( $GLOBALS['wp_version'], '5.9-alpha', '>=' ) ) {
 			$expected_count = 17;
@@ -557,7 +559,14 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 			];
 		}
 		if ( ! is_multisite() ) {
-			if ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
+			if ( version_compare( $GLOBALS['wp_version'], '7.2-alpha', '>=' ) ) {
+				array_splice(
+					$expected_values,
+					9,
+					0,
+					[ 'rest-setting-page_for_posts', 'rest-setting-page_for_privacy_policy', 'rest-setting-page_on_front', 'rest-setting-show_on_front', 'rest-setting-site_icon', 'rest-setting-site_logo' ]
+				);
+			} elseif ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
 				array_splice(
 					$expected_values,
 					9,
@@ -579,6 +588,13 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 					[ 'rest-setting-site_logo' ]
 				);
 			}
+		} elseif ( version_compare( $GLOBALS['wp_version'], '7.2-alpha', '>=' ) ) {
+			array_splice(
+				$expected_values,
+				9,
+				0,
+				[ 'blog-1-rest-setting-page_for_posts', 'blog-1-rest-setting-page_for_privacy_policy', 'blog-1-rest-setting-page_on_front', 'blog-1-rest-setting-show_on_front', 'blog-1-rest-setting-site_icon', 'blog-1-rest-setting-site_logo' ]
+			);
 		} elseif ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
 			array_splice(
 				$expected_values,

--- a/tests/phpunit/test-emitter-rest-api.php
+++ b/tests/phpunit/test-emitter-rest-api.php
@@ -509,18 +509,8 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 			$this->markTestSkipped( 'Test only applicable on single site.' );
 		}
 		wp_set_current_user( $this->admin_id1 );
-		$request        = new WP_REST_Request( 'GET', '/wp/v2/settings' );
-		$response       = $this->server->dispatch( $request );
-		$expected_count = 15;
-		if ( version_compare( $GLOBALS['wp_version'], '7.2-alpha', '>=' ) ) {
-			$expected_count = 21;
-		} elseif ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
-			$expected_count = 20;
-		} elseif ( version_compare( $GLOBALS['wp_version'], '5.9-alpha', '>=' ) ) {
-			$expected_count = 17;
-		} elseif ( version_compare( $GLOBALS['wp_version'], '5.8', '>=' ) ) {
-			$expected_count = 16;
-		}
+		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$this->server->dispatch( $request );
 		if ( ! is_multisite() ) {
 			$expected_values = [
 				'rest-setting-date_format',
@@ -588,13 +578,6 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 					[ 'rest-setting-site_logo' ]
 				);
 			}
-		} elseif ( version_compare( $GLOBALS['wp_version'], '7.2-alpha', '>=' ) ) {
-			array_splice(
-				$expected_values,
-				9,
-				0,
-				[ 'blog-1-rest-setting-page_for_posts', 'blog-1-rest-setting-page_for_privacy_policy', 'blog-1-rest-setting-page_on_front', 'blog-1-rest-setting-show_on_front', 'blog-1-rest-setting-site_icon', 'blog-1-rest-setting-site_logo' ]
-			);
 		} elseif ( version_compare( $GLOBALS['wp_version'], '6.0.3', '>=' ) ) {
 			array_splice(
 				$expected_values,
@@ -617,7 +600,6 @@ class Test_Emitter_REST_API extends Pantheon_Advanced_Page_Cache_Testcase {
 				[ 'blog-1-rest-setting-site_logo' ]
 			);
 		}
-		$this->assertCount( $expected_count, $response->get_data() );
 		$this->assertArrayValues(
 			$expected_values,
 			Emitter::get_rest_api_surrogate_keys()


### PR DESCRIPTION
WordPress nightly added a new setting, `page_for_privacy_policy`. The plugin emits one cache key per setting returned by `/wp/v2/settings`, so it emits one key more than `test_get_settings` expects and the test fails on the nightly run, while both stable runs pass. This adds the new key and the new total for WordPress 7.2-alpha and up.

`Tested up to` also moves from 7.0 to 7.1, in `readme.txt` and the plugin header, which clears the WP.org validator check.

Both failures are on `main`, so they are not specific to any open branch. The test failure takes the whole test matrix down with it.
